### PR TITLE
Ondersteuning voor een status veld in de suggesties. 

### DIFF
--- a/app/Enums/LanguageStatus.php
+++ b/app/Enums/LanguageStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Enum languageStatus
+ *
+ * Deze enumeratie voorziet de suggesties en de woord (artikelen) van statussen (in welke mate het woord als 'correct' gebruik hanteren).
+ * Hier is verkoezen om een enumeratie toe te passen voor dit. Aangezien het maar een select aantal opties zijn.
+ * De statussen worden tevens ook gemapt naar nummers om de opslag in de databank te optimaliseren.
+ * In deze enumeratie zullen we zo ook ineens doormiddel van een functie mappen naar het juiste label.
+ *
+ * @package App\Enums
+ */
+enum LanguageStatus: int implements HasLabel
+{
+    case StandaardNederlands = 1;
+    case StandaardBelgischNederlands = 2;
+    case KandidaatBelgischNederlands = 3;
+    case Onbekend = 4;
+    case GeenStandaardTaal = 5;
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::StandaardNederlands => 'Standaard nederlands',
+            self::StandaardBelgischNederlands => 'Standaard Belgisch-Nederlands',
+            self::KandidaatBelgischNederlands => 'Kandidaat Belgisch-Nederlands',
+            self::Onbekend => 'Onbekend',
+            self::GeenStandaardTaal => 'Geen standaardtaab'
+        };
+    }
+}

--- a/app/Enums/LanguageStatus.php
+++ b/app/Enums/LanguageStatus.php
@@ -31,7 +31,7 @@ enum LanguageStatus: int implements HasLabel
             self::StandaardBelgischNederlands => 'Standaard Belgisch-Nederlands',
             self::KandidaatBelgischNederlands => 'Kandidaat Belgisch-Nederlands',
             self::Onbekend => 'Onbekend',
-            self::GeenStandaardTaal => 'Geen standaardtaab'
+            self::GeenStandaardTaal => 'Geen standaardtaal',
         };
     }
 }

--- a/app/Filament/Resources/SuggestionResource.php
+++ b/app/Filament/Resources/SuggestionResource.php
@@ -90,7 +90,12 @@ final class SuggestionResource extends Resource
                         ->color('gray')
                         ->icon('heroicon-m-map')
                         ->badge()
-                        ->columnSpan(12),
+                        ->columnSpan(6),
+                    TextEntry::make('status')
+                        ->label('Status')
+                        ->color('gray')
+                        ->badge()
+                        ->columnSpan(6),
                 ])
         ]);
     }

--- a/app/Filament/Resources/SuggestionResource.php
+++ b/app/Filament/Resources/SuggestionResource.php
@@ -6,12 +6,8 @@ namespace App\Filament\Resources;
 
 use App\Enums\SuggestionStatus;
 use App\Filament\Resources\SuggestionResource\Pages;
-use App\Filament\Resources\SuggestionResource\RelationManagers;
 use App\Filament\Resources\SuggestionResource\Widgets\AdvancedStatsOverviewWidget;
 use App\Models\Suggestion;
-use Filament\Forms;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
@@ -21,8 +17,6 @@ use Filament\Support\Enums\IconSize;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 final class SuggestionResource extends Resource
 {
@@ -42,12 +36,12 @@ final class SuggestionResource extends Resource
             Section::make('Suggestie informatie')
                 ->description('Alle informatie die nodig is om aan de slag te kunnen met de ingezonden suggestie.')
                 ->compact()
-                ->icon(fn (Suggestion $suggestion): string => $suggestion->status->getIcon())
+                ->icon(fn (Suggestion $suggestion): string => $suggestion->state->getIcon())
                 ->iconSize(IconSize::Medium)
-                ->iconColor(fn (Suggestion $suggestion): string => $suggestion->status->getColor())
+                ->iconColor(fn (Suggestion $suggestion): string => $suggestion->state->getColor())
                 ->columns(12)
                 ->schema([
-                    TextEntry::make('status')
+                    TextEntry::make('state')
                         ->columnSpan(2)
                         ->badge()
                         ->label('Status v/d suggestie'),
@@ -58,18 +52,18 @@ final class SuggestionResource extends Resource
                         ->placeholder('onbekend'),
                     TextEntry::make('assignee.name')
                         ->label('Behandelaar')
-                        ->visible(fn(Suggestion $suggestion): bool => $suggestion->status->in(enums: [SuggestionStatus::New,  SuggestionStatus::InProgress]))
+                        ->visible(fn(Suggestion $suggestion): bool => $suggestion->state->in(enums: [SuggestionStatus::New,  SuggestionStatus::InProgress]))
                         ->translateLabel()
                         ->placeholder('- onbekend')
                         ->columnSpan(2),
                     TextEntry::make('rejecter.name')
                         ->label('Afgewezen door')
-                        ->visible(fn(Suggestion $suggestion): bool => $suggestion->status->is(SuggestionStatus::Rejected))
+                        ->visible(fn(Suggestion $suggestion): bool => $suggestion->state->is(SuggestionStatus::Rejected))
                         ->placeholder('- onbekend')
                         ->columnSpan(2),
                     TextEntry::make('approver.name')
                         ->label('Goedgekeurd door')
-                        ->visible(fn (Suggestion $suggestion): bool => $suggestion->status->is(SuggestionStatus::Accepted))
+                        ->visible(fn (Suggestion $suggestion): bool => $suggestion->state->is(SuggestionStatus::Accepted))
                         ->placeholder('- onbekend')
                         ->columnSpan(2),
                     TextEntry::make('word')

--- a/app/Filament/Resources/SuggestionResource/Actions/AcceptSuggestionAction.php
+++ b/app/Filament/Resources/SuggestionResource/Actions/AcceptSuggestionAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\SuggestionResource\Actions;
 
 use App\Contracts\ChecksAuthorizationBasedOnStatus;
+use App\Enums\LanguageStatus;
 use App\Enums\SuggestionStatus;
 use App\Models\Suggestion;
 use App\Models\Word;
@@ -62,6 +63,13 @@ final class AcceptSuggestionAction extends Action implements ChecksAuthorization
                         ->maxLength(255)
                         ->translateLabel()
                         ->columnSpan(8),
+                    Select::make('status')
+                        ->options(LanguageStatus::class)
+                        ->preload()
+                        ->native(false)
+                        ->minItems(1)
+                        ->maxItems(1)
+                        ->columnSpan(12),
                     Select::make('regions')
                         ->label("Regio's")
                         ->multiple()

--- a/app/Filament/Resources/SuggestionResource/Actions/AcceptSuggestionAction.php
+++ b/app/Filament/Resources/SuggestionResource/Actions/AcceptSuggestionAction.php
@@ -42,7 +42,7 @@ final class AcceptSuggestionAction extends Action implements ChecksAuthorization
             return false;
         }
 
-        return $model->status->notIn(enums: [SuggestionStatus::Accepted, SuggestionStatus::Rejected]);
+        return $model->state->notIn(enums: [SuggestionStatus::Accepted, SuggestionStatus::Rejected]);
     }
 
     private static function configureModalForm(): array
@@ -88,7 +88,7 @@ final class AcceptSuggestionAction extends Action implements ChecksAuthorization
     private static function configureModalAction(Suggestion $suggestion, array $data): mixed
     {
         return DB::transaction(function () use ($suggestion, $data): Word {
-            $suggestion->update(attributes: ['status' => SuggestionStatus::Accepted, 'approver_id' => auth()->user()->id]);
+            $suggestion->update(attributes: ['state' => SuggestionStatus::Accepted, 'approver_id' => auth()->user()->id]);
 
             // Start repllication process to the word table (Lemma's)
             return tap(self::createNewLemma($data), function (Word $lemma) use ($suggestion): void {

--- a/app/Filament/Resources/SuggestionResource/Actions/InProgressSuggestionAction.php
+++ b/app/Filament/Resources/SuggestionResource/Actions/InProgressSuggestionAction.php
@@ -28,14 +28,14 @@ final class InProgressSuggestionAction extends Action implements ChecksAuthoriza
 
     public static function performActionBasedOnStatus(Model $model): bool
     {
-        return $model->assignee()->doesntExist() && $model->status->is(SuggestionStatus::New);
+        return $model->assignee()->doesntExist() && $model->state->is(SuggestionStatus::New);
     }
 
     public static function performActionLogic(Suggestion $suggestion): mixed
     {
         return DB::transaction(function () use ($suggestion): mixed {
             return $suggestion->update(attributes: [
-                'assignee_id' => auth()->user()->getAuthIdentifier(), 'status' => SuggestionStatus::InProgress,
+                'assignee_id' => auth()->user()->getAuthIdentifier(), 'state' => SuggestionStatus::InProgress,
             ]);
         });
     }

--- a/app/Filament/Resources/SuggestionResource/Actions/RejectSuggestionAction.php
+++ b/app/Filament/Resources/SuggestionResource/Actions/RejectSuggestionAction.php
@@ -33,13 +33,13 @@ final class RejectSuggestionAction extends Action implements ChecksAuthorization
             return false;
         }
 
-        return $model->status->notIn(enums: [SuggestionStatus::Accepted, SuggestionStatus::Rejected]);
+        return $model->state->notIn(enums: [SuggestionStatus::Accepted, SuggestionStatus::Rejected]);
     }
 
     private static function performAction(Suggestion $suggestion): bool
     {
-        return DB::transaction(function () use ($suggestion): bool {
-            return $suggestion->update(['status' => SuggestionStatus::Rejected, 'rejector_id' => auth()->user()->id]);
+        return DB::transaction(function () use ($suggestion): bool|int {
+            return $suggestion->update(['state' => SuggestionStatus::Rejected, 'rejector_id' => auth()->user()->id]);
         });
     }
 }

--- a/app/Filament/Resources/SuggestionResource/Pages/ListSuggestions.php
+++ b/app/Filament/Resources/SuggestionResource/Pages/ListSuggestions.php
@@ -28,7 +28,7 @@ final class ListSuggestions extends ListRecords
                 ->label($status->getLabel())
                 ->icon($status->getIcon())
                 ->badgeColor('primary')
-                ->query(fn (Builder $query): Builder => $query->where('status', $status))
+                ->query(fn (Builder $query): Builder => $query->where('state', $status))
             )->toArray();
     }
 }

--- a/app/Filament/Resources/SuggestionResource/Widgets/AdvancedStatsOverviewWidget.php
+++ b/app/Filament/Resources/SuggestionResource/Widgets/AdvancedStatsOverviewWidget.php
@@ -26,7 +26,7 @@ final class AdvancedStatsOverviewWidget extends BaseWidget
     private function countSuggestions(SuggestionStatus $suggestionStatus)
     {
         return Cache::flexible($suggestionStatus->value . '_suggestions_count', [30, 60], function () use ($suggestionStatus) {
-            return Suggestion::where('status', $suggestionStatus)->count();
+            return Suggestion::where('state', $suggestionStatus)->count();
         });
     }
 }

--- a/app/Models/Suggestion.php
+++ b/app/Models/Suggestion.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\LanguageStatus;
 use App\Enums\SuggestionStatus;
 use App\Models\Relations\BelongsToManyRegions;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -15,10 +16,11 @@ class Suggestion extends Model
     use HasFactory;
     use BelongsToManyRegions;
 
-    protected $fillable = ['word', 'status', 'assignee_id', 'rejector_id', 'approver_id', 'description', 'example', 'characteristics'];
+    protected $fillable = ['word', 'state', 'assignee_id', 'rejector_id', 'approver_id', 'description', 'example', 'characteristics'];
 
     protected $attributes = [
-        'status' => SuggestionStatus::New
+        'state' => SuggestionStatus::New,
+        'status' => LanguageStatus::Onbekend,
     ];
 
     public function creator(): BelongsTo
@@ -44,7 +46,8 @@ class Suggestion extends Model
     protected function casts(): array
     {
         return [
-            'status' => SuggestionStatus::class,
+            'state' => SuggestionStatus::class,
+            'status' => LanguageStatus::class,
         ];
     }
 }

--- a/database/migrations/2025_02_08_185403_create_suggestions_table.php
+++ b/database/migrations/2025_02_08_185403_create_suggestions_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->foreignIdFor(User::class, 'approver_id')->nullable()->references('id')->on('users')->nullOnDelete();
             $table->foreignIdFor(User::class, 'rejector_id')->nullable()->references('id')->on('users')->nullOnDelete();
             $table->string('state')->comment('De behandelings status van de suggestie.');
-            $table->string('status');
+            $table->smallInteger('status');
             $table->string('word');
             $table->string('description');
             $table->text('example');

--- a/database/migrations/2025_02_08_185403_create_suggestions_table.php
+++ b/database/migrations/2025_02_08_185403_create_suggestions_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->foreignIdFor(User::class, 'assignee_id')->nullable()->references('id')->on('users')->nullOnDelete();
             $table->foreignIdFor(User::class, 'approver_id')->nullable()->references('id')->on('users')->nullOnDelete();
             $table->foreignIdFor(User::class, 'rejector_id')->nullable()->references('id')->on('users')->nullOnDelete();
+            $table->string('state')->comment('De behandelings status van de suggestie.');
             $table->string('status');
             $table->string('word');
             $table->string('description');


### PR DESCRIPTION
Deze PR voegt de implementatie toe van een status veld in de suggestie. 
Van de suggestie zal de status automatisch worden overgenomen. Naar de artikelen tabel. 

Alleen gebruikers met de volgende rollen hebben toegang tot het status veld: Developers, Administrators, Vrijwilligers