### PR TITLE
Ref: #5: TextArea omzetten naar RichEditor

### DIFF
--- a/app/Casts/ExampleArrtibute.php
+++ b/app/Casts/ExampleArrtibute.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+final readonly class ExampleArrtibute
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        $value = str_replace( '<p>', '', $value);
+        $value = str_replace( '</p>', '', $value);
+
+        return $value;
+    }
+}

--- a/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
+++ b/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
@@ -53,18 +53,7 @@ final readonly class FormSchema
                 ->required(),
             Components\RichEditor::make('example')
                 ->label('Voorbeeld')
-                ->toolbarButtons([
-                    'blockquote',
-                    'bold',
-                    'bulletList',
-                    'italic',
-                    'link',
-                    'orderedList',
-                    'redo',
-                    'strike',
-                    'underline',
-                    'undo',
-                ])
+                ->toolbarButtons(['bold', 'italic', 'link', 'redo', 'strike', 'underline', 'undo'])
                 ->placeholder('Probeer zo helder mogelijk te zijn')
                 ->columnSpan(12)
                 ->required()

--- a/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
+++ b/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
@@ -21,7 +21,7 @@ final readonly class FormSchema
     }
 
     /**
-     * @return array<int, Components\Select|Components\TextInput|Components\Textarea>
+     * @return array<int, Components\Select|Components\TextInput|Components\Textarea|Components\RichEditor>
      */
     public static function getDetailSchema(): array
     {
@@ -51,10 +51,21 @@ final readonly class FormSchema
                 ->cols(2)
                 ->placeholder('De beschrijving van het woord dat je wenst toe te voegen.')
                 ->required(),
-            Components\Textarea::make('example')
+            Components\RichEditor::make('example')
                 ->label('Voorbeeld')
+                ->toolbarButtons([
+                    'blockquote',
+                    'bold',
+                    'bulletList',
+                    'italic',
+                    'link',
+                    'orderedList',
+                    'redo',
+                    'strike',
+                    'underline',
+                    'undo',
+                ])
                 ->placeholder('Probeer zo helder mogelijk te zijn')
-                ->cols(2)
                 ->columnSpan(12)
                 ->required()
                 ->maxLength(255),

--- a/app/Filament/Resources/ArticleResource/Schema/WordInfolist.php
+++ b/app/Filament/Resources/ArticleResource/Schema/WordInfolist.php
@@ -8,6 +8,7 @@ use Filament\Infolists\Components\Tabs;
 use Filament\Infolists\Components\Tabs\Tab;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
+use Illuminate\Support\HtmlString;
 
 final readonly class WordInfolist
 {
@@ -64,6 +65,7 @@ final readonly class WordInfolist
                     ->columnSpan(5),
                 TextEntry::make('example')
                     ->label('Voorbeeld')
+                    ->formatStateUsing(fn (string $state): HtmlString => new HtmlString($state))
                     ->columnSpan(7),
             ]);
     }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Casts\ExampleArrtibute;
 use App\States\Articles;
 use App\Contracts\States\ArticleStateContract;
 use App\Enums\ArticleStates;
@@ -145,6 +146,7 @@ final class Article extends Model implements AuditableContract
         return [
             'state' => ArticleStates::class,
             'status' => LanguageStatus::class,
+            'example' => ExampleArrtibute::class,
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,11 +8,14 @@ use App\Models\User;
 use App\UserTypes;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 final class AppServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        Paginator::useBootstrapFive();
+
         $this->registerGlobalPolicyCheck();
     }
 

--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -12,6 +12,7 @@ final readonly class SearchWordQuery
     {
         return Article::query()
             ->where('word', 'LIKE', "%{$searchTerm}%")
-            ->paginate();
+            ->paginate()
+            ->withQueryString();
     }
 }

--- a/app/States/Articles/ApprovalState.php
+++ b/app/States/Articles/ApprovalState.php
@@ -6,18 +6,44 @@ namespace App\States\Articles;
 
 use App\Enums\ArticleStates;
 
+/**
+ * ApprovalState represents an article awaiting editorial review in the Vlaams Woordenboek.
+ *
+ * This state indicates that the article has been submitted for review and requires editorial approval before publication.
+ * The state provides multiple transition paths to support various editorial decisions: returning to draft for further editing, approving for publication, or archiving if deemed unsuitable.
+ *
+ * @package App\States\Articles
+ */
 final class ApprovalState extends ArticleState
 {
+    /**
+     * Returns the article to draft status for additional editing.
+     *
+     * This transition is typically used when the reviewing editor determines that the article needs further refinement before it can be published.
+     * The article returns to a draft state where authors can make the requested changes.
+     */
     public function transitionToEditing(): void
     {
         $this->article->update(attributes: ['state' => ArticleStates::Draft]);
     }
 
+    /**
+     * Approves the article and transitions it to published status.
+     *
+     * This transition occurs when an editor determines the article meets all quality standards and is ready for public viewing.
+     * The article becomes visible to all users once published.
+     */
     public function transitionToReleased(): void
     {
         $this->article->update(attributes: ['state' => ArticleStates::Published]);
     }
 
+    /**
+     * Archives the article, removing it from the active review process.
+     *
+     * This transition is used when an editor decides the article should not be published but should be retained for reference.
+     * Archived articles can be restored later if circumstances change.
+     */
     public function transitionToArchived(): void
     {
         $this->article->update(attributes: ['state' => ArticleStates::Archived]);

--- a/app/States/Articles/ArchivedState.php
+++ b/app/States/Articles/ArchivedState.php
@@ -6,8 +6,23 @@ namespace App\States\Articles;
 
 use App\Enums\ArticleStates;
 
+/**
+ * ArchivedState represents the archived status of a dictionary article.
+ *
+ * This state indicates that an article has been temporarily removed from public view but remains in the system for historical reference or potential future restoration.
+ * Articles in this state can be transitioned back to published status if needed, providing flexibility in content management while maintaining data integrity.
+ *
+ * @package App\States\Articles
+ */
 final class ArchivedState extends ArticleState
 {
+    /**
+     * Transitions an archived article back to published status.
+     *
+     * This method enables content restoration by changing the article's state from archived to published.
+     * This transition might be used when previously archived content becomes relevant again or when an article was archived by mistake.
+     * The change is immediately persisted to the database through the article model.
+     */
     public function transitionToReleased(): void
     {
         $this->article->update(attributes: ['state' => ArticleStates::Published]);

--- a/app/States/Articles/ArticleState.php
+++ b/app/States/Articles/ArticleState.php
@@ -26,7 +26,7 @@ class ArticleState implements ArticleStateContract
 
     public function transitionToEditing(): void
     {
-        throw new LogicException('The method transitionTOEditing() is not allowed in the current state.');
+        throw new LogicException('The method tran   sitionTOEditing() is not allowed in the current state.');
     }
 
     public function transitionToReleased(): void

--- a/resources/views/components/definitions/word-information.blade.php
+++ b/resources/views/components/definitions/word-information.blade.php
@@ -7,33 +7,37 @@
 @section ('content')
     <div class="card bg-white border-0 shadow-sm">
         <div class="card-body">
-            <h4 class="text-gold mb-0 border-bottom py-1">{{ $word->word }} <span class="text-muted fs-6">({{ $word->characteristics }})</span></h4>
+            <h1 class="text-gold">{{ $word->word }}</h1>
 
-            <ul class="list-inline mt-1">
-                <li class="list-inline-item">
-                    <x-heroicon-o-user-circle class="icon me-1"/>
-                    <span class="text-muted">{{ $word->author->name ?? 'onbekend' }}</span>
-                </li>
-                <li class="list-inline-item">
-                    <x-heroicon-o-tag class="icon me-1"/>
-                    <span class="text-muted">{{ $word->status->getLabel() }}</span>
-                </li>
+            <ul class="list-unstyled mb-0 text-muted border-bottom pb-2">
+                <li>{{ $word->characteristics }}</li>
+                <li>{{ $word->status->getLabel() }}</li>
             </ul>
 
-            <div class="mt-4 mb-2">
-                <dl class="row mb-0">
-                    <dt class="col-sm-3">Beschrijving</dt>
-                    <dd class="col-sm-9">{{ $word->description }}</dd>
-                    <dt class="col-sm-3">Voorbeeld</dt>
-                    <dd class="col-sm-9">{{ $word->example }}</dd>
-                    <dt class="col-sm-3">Regio's</dt>
-                    <dd class="col-md-9">
-                        @foreach ($word->regions as $region)
-                            <span>{{ $region->name }}@if(! $loop->last),@endif</span>
-                        @endforeach
-                    </dd>
-                </dl>
-            </div>
+            <p class="mb-0 py-2">
+                <strong class="color-green">Regios:</strong></br>
+            </p>
+
+            <ul class="list-unstyled border-bottom mb- pb-2">
+                @forelse ($word->regions as $region)
+                    <li>
+                        <x-heroicon-o-map class="icon me-1"/> {{ $region->name }}
+                    </li>
+                @empty
+                    <li>- Geen regio voor het woord gevonden</li>
+                @endforelse
+            </ul>
+
+            <p class="border-bottom mb-0 py-2">
+                <strong class="color-green">Beschrijving:</strong></br>
+                {{ $word->description }}
+            </p>
+
+            <p class="pt-2 mb-0">
+                <strong class="color-green">Voorbeeld:</strong>
+            </p>
+
+            {!! str($word->example)->sanitizeHtml() !!}
         </div>
 
         <div class="card-footer bg-white">
@@ -41,23 +45,6 @@
         </div>
     </div>
 
-    <div class="py-4">
-        <ul class="nav nav-tabs">
-            <li class="nav-item">
-                <a class="nav-link active" aria-current="page" href="#">Definities</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#">
-                    Reacties
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#">Revisies</a>
-            </li>
-        </ul>
-    </div>
-
-    @yield('information-tab')
 @endsection
 
 @section ('additional-sidenav-components')

--- a/resources/views/definitions/show.blade.php
+++ b/resources/views/definitions/show.blade.php
@@ -1,7 +1,2 @@
 @extends ('components.definitions.word-information')
 
-@section('information-tab')
-    <div class="card border-0 shadow-sm bg-white">
-        <div class="card-body">ff</div>
-    </div>
-@endsection

--- a/resources/views/livewire/like-words.blade.php
+++ b/resources/views/livewire/like-words.blade.php
@@ -10,14 +10,18 @@
                     <x-heroicon-o-hand-thumb-down class="icon me-1"/> Downvote
                 </button>
             @endif
+
+            <span class="ms-2 text-dark">
+                    Upvotes: <span class="fw-bold">{{ $upvotes }}</span>
+                </li>
+            </span>
         </div>
     @endauth
 
     <div class="float-end">
         <ul class="list-inline mb-0">
-            <li class="list-inline-item text-muted">
-                <x-heroicon-s-hand-thumb-up class="icon text-success me-1"/>
-                Upvotes: <span class="fw-bold">{{ $upvotes }}</span>
+            <li class="list-inline-item fst-italic text-muted">
+                Ingestuurd door: <span class="fw-bold">{{ $word->author->name ?? 'onbekend gebruiker' }}</span>
             </li>
         </ul>
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,43 +23,33 @@
 
                 @if (request()->has('zoekterm') && $results->total() > 0)
                     <div class="card bg-white border-0 shadow-sm">
-                        <div class="card-header text-dark bg-white">Zoekresultaten voor: <strong>'{{ request()->get('zoekterm') }}'</strong></div>
-                        <div class="card-body">
-                            <div class="table-responsive">
-                                <table class="table table-sm table-hover">
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">Woord</th>
-                                            <th scope="col">Auteur</th>
-                                            <th scope="col">Voorbeeld</th>
-                                            <th scope="col">&nbsp;</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        @foreach ($results as $result)
-                                            <tr>
-                                                <th scope="row" class="color-green">{{ $result->word }}</th>
-                                                <td>{{ $result->author->name ?? '-' }}</td>
-                                                <td class="text-muted">{{ $result->example }}</td>
-                                                <td>
-                                                    <a href="{{ route('word-information.show', $result) }}" class="float-end text-decoration-none">
-                                                        <x-heroicon-o-eye class="icon me-1"/> Bekijken
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                        @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
+                        <div class="card-header">Zoekresultaten voor: <strong>'{{ request()->get('zoekterm') }}'</strong></div>
+                        <div class="list-group list-group-flush">
+                            @foreach ($results as $result)
+                                <a href="{{ route('word-information.show', $result) }}" class="list-group-item list-group-item-action" aria-current="true">
+                                    <div class="d-flex w-100 justify-content-between">
+                                        <h5 class="mb-1 color-green">{{ $result->word }}</h5>
 
-                        @if ($results->hasPages())
-                            <div class="card-footer bg-white">
-                                <span class="float-start">{{ $results->links() }}</span>
-                                <span class="float-end"></span>
-                            </div>
-                        @endif
+                                        <small class="text-muted">
+                                            {{ $result->created_at->diffForHumans() }}
+                                        </small>
+                                    </div>
+
+                                    <p class="mb-2">{{ $result->description }}</p>
+
+                                    @if ($result->author)
+                                        <small class="text-muted">Ingestuurd door: <strong>{{ $result->author->name }}</strong></small>
+                                    @endif
+                                </a>
+                            @endforeach
+                        </div>
                     </div>
+
+                    @if ($results->hasPages())
+                        <div class="py-3 mt-3 border-top">
+                            {{ $results->links() }}
+                        </div>
+                    @endif
                 @else
 
                     <div class="alert alert-info alert-important shadow-sm" role="alert">


### PR DESCRIPTION
Bij het creeren en wijzigen van een woordenboek artikel in de beheersconsole hadden we een textarea die ons toeliet om een voorbeeld van een woord op te slaan. Dit veld is omgezet naar een rich editor veld. Zodat we zaken zoals links, vette tekst, oplijsten, [enz...](https://github.com/Tjoosten/vl-woordenboek/compare/develop...fix-5?expand=1#diff-5c86fea0f66540967e70fd27638a63579f844639c210b0d01688c2b13b1495abR56-R67) kunnen ondersteunen. 

En daarbij zou ook #5 kunnen gesloten worden wegens dat dit ticket verholpen is. 