### PR TITLE
Toevoegen van de ondersteuning voor kernwoorden aan de artikelen

### DIFF
--- a/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
+++ b/app/Filament/Resources/ArticleResource/Schema/FormSchema.php
@@ -45,6 +45,11 @@ final readonly class FormSchema
                 ->columnSpan(6)
                 ->required()
                 ->maxLength(255),
+            Components\TextInput::make('keywords')
+                ->label('Kernwoorden')
+                ->translateLabel()
+                ->placeholder('Kernwoord 1, Kernwoord 2, Kernwoord 3, etc...')
+                ->columnSpanFull(),
             Components\Textarea::make('description')
                 ->label('Beschrijving')
                 ->columnSpan(12)

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -33,6 +33,7 @@ use Kenepa\ResourceLock\Models\Concerns\HasLocks;
  * @property int            $id               The unique identifier for the article
  * @property string         $word             The dictionary word being defined
  * @property ArticleStates  $state            The current state of the article in its lifecycle
+ * @property string|null    $keywords         The keywords that are attached to the article
  * @property string         $description      The detailed explanation of the word
  * @property int            $author_id        The ID of the user who created the article
  * @property LanguageStatus $status           The current language validation status
@@ -60,7 +61,7 @@ final class Article extends Model implements AuditableContract
      *
      * @var list<string>
      */
-    protected $fillable = ['word', 'state', 'description', 'author_id', 'status', 'example', 'characteristics'];
+    protected $fillable = ['word', 'state', 'description', 'keywords', 'author_id', 'status', 'example', 'characteristics'];
 
     /**
      * Attributes excluded from the audit trail.

--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -12,6 +12,7 @@ final readonly class SearchWordQuery
     {
         return Article::query()
             ->where('word', 'LIKE', "%{$searchTerm}%")
+            ->orWhere('keywords', 'LIKE', "%{$searchTerm}%")
             ->paginate()
             ->withQueryString();
     }

--- a/database/migrations/2025_02_10_131512_create_articles_table.php
+++ b/database/migrations/2025_02_10_131512_create_articles_table.php
@@ -25,6 +25,7 @@ return new class extends Migration
             $table->string('word');
             $table->smallInteger('status');
             $table->string('description');
+            $table->text('keywords')->nullable();
             $table->text('example');
             $table->text('characteristics');
             $table->timestamps();


### PR DESCRIPTION
Deze pull request voegt de ondersteuning toe van kernwoorden aan de woordenboek artikelen. Echter zullen deze kernwoorden momenteel alleen maar zichtbaar zijn in de beheersconsole. En meegenomen worden in de zoek query voor de frontend. 

Voorbeeld van de beheersconsole: 

![image](https://github.com/user-attachments/assets/52b1b437-6123-4142-893a-64668ce5d59a)
