### PR TITLE
Implementatie global rate limiter. 

### DIFF
--- a/app/Http/Controllers/Web/Account/AccountSettingsController.php
+++ b/app/Http/Controllers/Web/Account/AccountSettingsController.php
@@ -14,7 +14,7 @@ use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Prefix;
 
 #[Prefix('instellingen')]
-#[Middleware(['auth', 'forbid-banned-user'])]
+#[Middleware(['auth', 'forbid-banned-user', 'throttle:global'])]
 final readonly class AccountSettingsController
 {
     public function __construct(

--- a/app/Http/Controllers/Web/Account/DeleteAccountController.php
+++ b/app/Http/Controllers/Web/Account/DeleteAccountController.php
@@ -30,7 +30,7 @@ final readonly class DeleteAccountController
      * @param  DeleteAccount         $deleteAccount         The account deletion action
      * @return RedirectResponse                             Redirects to the homepage after deletion.
      */
-    #[Post(uri: '/account-verwijderen', name: 'account.delete', middleware: ['auth', 'forbid-banned-user'])]
+    #[Post(uri: '/account-verwijderen', name: 'account.delete', middleware: ['auth', 'forbid-banned-user', 'throttle:global'])]
     public function __invoke(DeleteAccountRequest $deleteAccountRequest, DeleteAccount $deleteAccount): RedirectResponse
     {
         $deleteAccount($deleteAccountRequest);

--- a/app/Http/Controllers/Web/Articles/BookmarkController.php
+++ b/app/Http/Controllers/Web/Articles/BookmarkController.php
@@ -13,7 +13,7 @@ use Illuminate\Http\Request;
 use Spatie\RouteAttributes\Attributes\Get;
 use Spatie\RouteAttributes\Attributes\Middleware;
 
-#[Middleware(middleware: ['auth', 'forbid-banned-user'])]
+#[Middleware(middleware: ['auth', 'forbid-banned-user', 'throttle:global'])]
 final readonly class BookmarkController
 {
     /**

--- a/app/Http/Controllers/Web/Articles/DictionaryArticleController.php
+++ b/app/Http/Controllers/Web/Articles/DictionaryArticleController.php
@@ -28,7 +28,7 @@ final readonly class DictionaryArticleController
      * @param  Article $word  The dictionary entry to display
      * @return Renderable     The view containing article details
      */
-    #[Get(uri: '/woordenboek-artikel/{word}', name: 'word-information.show')]
+    #[Get(uri: '/woordenboek-artikel/{word}', name: 'word-information.show', middleware: ['throttle:global'])]
     public function __invoke(Article $word): Renderable
     {
         abort_if($word->isHidden(), Response::HTTP_NOT_FOUND);

--- a/app/Http/Controllers/Web/Articles/RandomDictionaryArticleController.php
+++ b/app/Http/Controllers/Web/Articles/RandomDictionaryArticleController.php
@@ -10,7 +10,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 
 final readonly class RandomDictionaryArticleController
 {
-    #[Get(uri: '/willekeurig-woordenboek-artikel', name: 'word-information.random')]
+    #[Get(uri: '/willekeurig-woordenboek-artikel', name: 'word-information.random', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         $article = Article::whereNotNull('published_at')->inRandomOrder()->first();

--- a/app/Http/Controllers/Web/Articles/RegionInformationController.php
+++ b/app/Http/Controllers/Web/Articles/RegionInformationController.php
@@ -25,7 +25,7 @@ final readonly class RegionInformationController
      *
      * @return Renderable  The view containing regional information.
      */
-    #[Get(uri: 'regio-informatie', name: 'definitions.region-info')]
+    #[Get(uri: 'regio-informatie', name: 'definitions.region-info', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         return view('region-information');

--- a/app/Http/Controllers/Web/Articles/ReportController.php
+++ b/app/Http/Controllers/Web/Articles/ReportController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 #[Middleware(middleware: ['auth', 'forbid-banned-user'])]
 final readonly class ReportController
 {
-    #[Post(uri: '/{article}/rapportering', name: 'article-report.create')]
+    #[Post(uri: '/{article}/rapportering', name: 'article-report.create', middleware: ['throttle:global'])]
     public function __invoke(StoreReportRequest $storeReportRequest, StoreArticleReport $storeArticleReport, Article $article): RedirectResponse
     {
         $storeArticleReport->execute($storeReportRequest, $article);

--- a/app/Http/Controllers/Web/Articles/SearchController.php
+++ b/app/Http/Controllers/Web/Articles/SearchController.php
@@ -29,8 +29,8 @@ final readonly class SearchController
      * @param  SearchWordQuery $searchWordQuery  The search query service
      * @return Renderable                        The view with optional search results
      */
-    #[Get(uri: '/', name: 'home')]
-    #[Get(uri: '/resultaten', name: 'search.results')]
+    #[Get(uri: '/', name: 'home', middleware: ['throttle:global'])]
+    #[Get(uri: '/resultaten', name: 'search.results', middleware: ['throttle:global'])]
     public function __invoke(Request $request, SearchWordQuery $searchWordQuery): Renderable
     {
         return view('welcome', [

--- a/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
+++ b/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\RateLimiter;
 use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Post;
 
 /**
@@ -24,6 +25,7 @@ use Spatie\RouteAttributes\Attributes\Post;
  *
  * @package App\Http\Controllers\Web\Articles
  */
+#[Middleware(middleware: ['throttle:global'])]
 final class StoreArticleSuggestionController
 {
     use RateLimitSubmission;

--- a/app/Http/Controllers/Web/Info/ProjectInformationController.php
+++ b/app/Http/Controllers/Web/Info/ProjectInformationController.php
@@ -11,7 +11,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 
 final readonly class ProjectInformationController
 {
-    #[Get(uri: 'project-informatie', name: 'project-information')]
+    #[Get(uri: 'project-informatie', name: 'project-information', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         $settings = app(ProjectInformationSettings::class);

--- a/app/Http/Controllers/Web/Legal/TermsOfServiceController.php
+++ b/app/Http/Controllers/Web/Legal/TermsOfServiceController.php
@@ -27,7 +27,7 @@ final readonly class TermsOfServiceController
      *
      * @return Renderable  The view containing terms of service content
      */
-    #[Get(uri: 'voorwaarden', name: 'terms-of-service')]
+    #[Get(uri: 'voorwaarden', name: 'terms-of-service', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         return view('info.terms');

--- a/app/Http/Controllers/Web/Statistics/DictionaryStatistics.php
+++ b/app/Http/Controllers/Web/Statistics/DictionaryStatistics.php
@@ -12,7 +12,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 
 final class DictionaryStatistics extends Controller
 {
-    #[Get(uri: 'statistieken', name: 'statistics')]
+    #[Get(uri: 'statistieken', name: 'statistics', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         $statistics = new StatisticService();

--- a/app/Http/Controllers/Web/Suggestions/OverviewController.php
+++ b/app/Http/Controllers/Web/Suggestions/OverviewController.php
@@ -26,7 +26,7 @@ final readonly class OverviewController
      * @param  Request $request  The incoming HTTP request.
      * @return Renderable        The rendered view of user suggestions.
      */
-    #[Get(uri: 'mijn-suggesties', name: 'suggestions:index', middleware: ['auth', 'forbid-banned-user'])]
+    #[Get(uri: 'mijn-suggesties', name: 'suggestions:index', middleware: ['auth', 'forbid-banned-user', 'throttle:global'])]
     public function __invoke(Request $request): Renderable
     {
         $suggestionQuery = new UserSuggestionQueryBuilder($request);

--- a/app/Http/Controllers/Web/Support/VolunteersController.php
+++ b/app/Http/Controllers/Web/Support/VolunteersController.php
@@ -10,7 +10,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 
 final readonly class VolunteersController
 {
-    #[Get(uri: 'ondersteuning/vrijwilligers', name: 'support.volunteers')]
+    #[Get(uri: 'ondersteuning/vrijwilligers', name: 'support.volunteers', middleware: ['throttle:global'])]
     public function __invoke(): Renderable
     {
         return view('info.volunteers-callout', [

--- a/app/Providers/RateLimitServiceProvider.php
+++ b/app/Providers/RateLimitServiceProvider.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\UserTypes;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\ServiceProvider;
 
 final class RateLimitServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        RateLimiter::for('submissions', function (Request $request): Limit {
-            return Limit::perMinute(1)->by();
+        RateLimiter::for('global', static function (Request $request): Limit {
+            $limit = $request->user()->user_type->not(UserTypes::Normal)
+                ? Limit::none()
+                : Limit::perHour(250);
+
+            return $limit->response(function (Request $request, array $headers): Response {
+                return response('Het lijkt erop dat je momenteel de limit van 250 requests per uur hebt overschreden probeer binnen een uur nog eens', 420, $headers);
+            });
         });
     }
 }

--- a/app/Providers/RateLimitServiceProvider.php
+++ b/app/Providers/RateLimitServiceProvider.php
@@ -16,7 +16,7 @@ final class RateLimitServiceProvider extends ServiceProvider
     public function boot(): void
     {
         RateLimiter::for('global', static function (Request $request): Limit {
-            $limit = $request->user()?->user_type->not(UserTypes::Normal)
+            $limit = $request->user()?->user_type->isNot(UserTypes::Normal)
                 ? Limit::none()
                 : Limit::perHour(250);
 

--- a/app/Providers/RateLimitServiceProvider.php
+++ b/app/Providers/RateLimitServiceProvider.php
@@ -16,7 +16,7 @@ final class RateLimitServiceProvider extends ServiceProvider
     public function boot(): void
     {
         RateLimiter::for('global', static function (Request $request): Limit {
-            $limit = $request->user()->user_type->not(UserTypes::Normal)
+            $limit = $request->user()?->user_type->not(UserTypes::Normal)
                 ? Limit::none()
                 : Limit::perHour(250);
 

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,6 +4,7 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Providers\AuthorizationServiceProvider::class,
     App\Providers\Filament\AdminPanelProvider::class,
+    App\Providers\RateLimitServiceProvider::class,
     App\Providers\FortifyServiceProvider::class,
     App\Providers\QueueServiceProvider::class,
 ];


### PR DESCRIPTION
Deze pull request voegt de bescherming toe van een globale rate limiter. 
Het heeft als functie om de gebruikers hun verzoeken en raadplegingen op het vlaams woordenboek te limiteren naar 250 requests per uur. Zodat we preventief scammers en scrapers kunnen afblokken. 
