### PR TITLE
Prunen van inactivate accounts

### DIFF
--- a/app/Console/Commands/Reminders/InactivityWarningCommand.php
+++ b/app/Console/Commands/Reminders/InactivityWarningCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Reminders;
+
+use App\Models\User;
+use App\Notifications\InactivityWarningNotification;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'users:inactivity-warning', description: 'Send a inactivity warning reminder to admins before pruning articles')]
+final class InactivityWarningCommand extends Command
+{
+    public function handle(): void
+    {
+        $usersToWarn = User::query()->where('last_seen_at', '<', $this->getWarningThreshold())
+            ->whereNull('inactivity_warning_sent_at')
+            ->get();
+
+        $usersToWarn->each(static function (User $user) {
+           $user->notify(new InactivityWarningNotification());
+           $user->update(['inactivity_warning_sent_at' => now()]);
+        });
+    }
+
+    private function getWarningThreshold(): Carbon
+    {
+        return now()->subMonths(5);
+    }
+}

--- a/app/Listeners/LastSeenAtListener.php
+++ b/app/Listeners/LastSeenAtListener.php
@@ -15,6 +15,6 @@ final readonly class LastSeenAtListener
         $userEntity = $loginEvent->user;
 
         $authenticatedUser = User::query()->findOrFail($userEntity->id);
-        $authenticatedUser->update(['last_seen_at' => now()]);
+        $authenticatedUser->update(['last_seen_at' => now(), 'inactivity_warning_sent_at' => null]);
     }
 }

--- a/app/Mail/AccountPrunedMailable.php
+++ b/app/Mail/AccountPrunedMailable.php
@@ -21,7 +21,7 @@ final class AccountPrunedMailable extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: 'Account Pruned Mailable',
+            subject: 'Account verwijderd van het Vlaams Woordenboek',
         );
     }
 

--- a/app/Mail/AccountPrunedMailable.php
+++ b/app/Mail/AccountPrunedMailable.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+final class AccountPrunedMailable extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Account Pruned Mailable',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            text: 'emails.account-deleted'
+        );
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Builders\UserBuilder;
+use App\Mail\AccountPrunedMailable;
 use App\Models\Relations\Contactable;
+use App\Notifications\AccountDeletedNotification;
 use App\Notifications\RegistrationWelcomeNotification;
 use App\UserTypes;
 use Carbon\Carbon;
@@ -13,10 +15,13 @@ use Cmgmyr\Messenger\Traits\Messagable;
 use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Mail;
 use Spatie\WelcomeNotification\ReceivesWelcomeNotification;
 use Overtrue\LaravelLike\Traits\Liker;
 use Cog\Contracts\Ban\Bannable as BannableInterface;
@@ -37,29 +42,29 @@ use Spatie\Permission\Traits\HasRoles;
  * It supports role-based access control through user types, welcome notifications for new users,
  * and interaction tracking through the "likes" system.
  *
- * @property int          $id                 Unique identifier for the user
- * @property string       $name               The unique username from the account
- * @property string       $firstname          User's first name
- * @property string       $lastname           User's last name
- * @property string       $email              User's email address for authentication
- * @property ?string	  $bio			      A short description of the user in the platform
- * @property ?string	  $twitter		      The URL to the twitter account of the user.
- * @property ?string	  $bluesky	          The URL to the bluesky account of the user.
- * @property ?string      $website			  The URL to the website of the user
- * @property UserTypes    $user_type          The assigned role group
- * @property string       $password           Hashed password for authentication
- * @property Carbon|null  $last_seen_at       Timestamp of last activity
- * @property Carbon|null  $email_verified_at  Timestamp of email verification
- * @property string|null  $remember_token     Token for the "remember me" feature
- * @property Carbon|null  $banned_at          Timestamp from when the user account has been banned.
- * @property bool         $is_beta_tester     Indicates that the user is a beta tester of not.
- * @property Carbon       $created_at         Timestamp of account creation
- * @property Carbon       $updated_at         Timestamp of the last update
+ * @property int $id                 Unique identifier for the user
+ * @property string $name               The unique username from the account
+ * @property string $firstname          User's first name
+ * @property string $lastname           User's last name
+ * @property string $email              User's email address for authentication
+ * @property ?string $bio                  A short description of the user in the platform
+ * @property ?string $twitter              The URL to the twitter account of the user.
+ * @property ?string $bluesky              The URL to the bluesky account of the user.
+ * @property ?string $website              The URL to the website of the user
+ * @property UserTypes $user_type          The assigned role group
+ * @property string $password           Hashed password for authentication
+ * @property Carbon|null $last_seen_at       Timestamp of last activity
+ * @property Carbon|null $email_verified_at  Timestamp of email verification
+ * @property string|null $remember_token     Token for the "remember me" feature
+ * @property Carbon|null $banned_at          Timestamp from when the user account has been banned.
+ * @property bool $is_beta_tester     Indicates that the user is a beta tester of not.
+ * @property Carbon $created_at         Timestamp of account creation
+ * @property Carbon $updated_at         Timestamp of the last update
  *
  * @method bans()
  * @method static UserBuilder|static query()
  * @method UserBuilder newQuery()
- * @method searchContributions(string $string,?string $string1, string $etymology)
+ * @method searchContributions(string $string, ?string $string1, string $etymology)
  *
  * @package App\Models
  */
@@ -77,6 +82,7 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
     use Messagable;
     use Contactable;
     use TwoFactorAuthenticatable;
+    use Prunable;
 
     /**
      * Specifies which attributes can be mass assigned when creating or updating user records.
@@ -84,7 +90,7 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
      *
      * @var list<string>
      */
-    protected $fillable = ['name', 'bluesky', 'twitter', 'website', 'firstname', 'lastname', 'is_beta_tester', 'email', 'user_type', 'password', 'last_seen_at', 'email_verified_at', 'google_id', 'google_token', 'google_refresh_token'];
+    protected $fillable = ['name', 'bluesky', 'twitter', 'website', 'firstname', 'lastname', 'inactivity_warning_sent_at', 'is_beta_tester', 'email', 'user_type', 'password', 'last_seen_at', 'email_verified_at', 'google_id', 'google_token', 'google_refresh_token'];
 
     /**
      * Defines default values for new user instances.
@@ -184,7 +190,7 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
      * Sends the initial welcome notification to newly created users.
      * The notification includes a time-limited link for setting up their password and activating their account.
      *
-     * @param  Carbon $validUntil Expiration timestamp for the welcome link.
+     * @param Carbon $validUntil Expiration timestamp for the welcome link.
      */
     public function sendWelcomeNotification(Carbon $validUntil): void
     {
@@ -197,7 +203,7 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
      * This method ensures that all queries for the User model use the custom builder,
      * which includes additional methods for managing user types and such.
      *
-     * @param  Builder $query  The base query builder instance
+     * @param Builder $query The base query builder instance
      * @return UserBuilder     The custom builder instance
      */
     #[Override]
@@ -209,6 +215,19 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
     public function isTester(): bool
     {
         return $this->is_beta_tester;
+    }
+
+    public function prunable(): EloquentBuilder
+    {
+        return static::where('last_seen_at', '<', now()->subMonths(6))
+            ->whereNotNull('inactivity_warning_sent_at');
+    }
+
+    protected function pruning(): void
+    {
+        $this->suggestions()->update(['contributor_name' => $this->name]);
+
+        Mail::to($this->email)->queue(new AccountPrunedMailable());
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,12 +9,14 @@ use App\Mail\AccountPrunedMailable;
 use App\Models\Relations\Contactable;
 use App\Notifications\AccountDeletedNotification;
 use App\Notifications\RegistrationWelcomeNotification;
+use App\Observers\UserObserver;
 use App\UserTypes;
 use Carbon\Carbon;
 use Cmgmyr\Messenger\Traits\Messagable;
 use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Prunable;
@@ -68,6 +70,7 @@ use Spatie\Permission\Traits\HasRoles;
  *
  * @package App\Models
  */
+#[ObservedBy(UserObserver::class)]
 class User extends Authenticatable implements FilamentUser, BannableInterface, MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
@@ -225,8 +228,6 @@ class User extends Authenticatable implements FilamentUser, BannableInterface, M
 
     protected function pruning(): void
     {
-        $this->suggestions()->update(['contributor_name' => $this->name]);
-
         Mail::to($this->email)->queue(new AccountPrunedMailable());
     }
 

--- a/app/Notifications/InactivityWarningNotification.php
+++ b/app/Notifications/InactivityWarningNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class InactivityWarningNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Je account is gemarkeerd voor verwijdering')
+            ->greeting("Hey {$notifiable->name},")
+            ->line('We merken dat het al 5 maanden geleden is dat je bent aangemeld voor het Vlaams Woordenboek')
+            ->line('Om niet onnodig gegevens van gebruikers te bewaren hebben je account gemarkeerd voor verwijderen. En zal verwijderd worden op ' . now()->addMonths(6)->format('d-m-Y'))
+            ->line('Om de toegang tot je account te behouden vragen we je om aan te melden op het Vlaams Woordenboek om de automatische verwijdering te stoppen');
+    }
+}

--- a/app/Notifications/InactivityWarningNotification.php
+++ b/app/Notifications/InactivityWarningNotification.php
@@ -27,8 +27,8 @@ class InactivityWarningNotification extends Notification implements ShouldQueue
         return (new MailMessage)
             ->subject('Je account is gemarkeerd voor verwijdering')
             ->greeting("Hey {$notifiable->name},")
-            ->line('We merken dat het al 5 maanden geleden is dat je bent aangemeld voor het Vlaams Woordenboek')
-            ->line('Om niet onnodig gegevens van gebruikers te bewaren hebben je account gemarkeerd voor verwijderen. En zal verwijderd worden op ' . now()->addMonths(6)->format('d-m-Y'))
-            ->line('Om de toegang tot je account te behouden vragen we je om aan te melden op het Vlaams Woordenboek om de automatische verwijdering te stoppen');
+            ->line('We merken dat het al 5 maanden geleden is dat je bent aangemeld voor het Vlaams Woordenboek.')
+            ->line('Om niet onnodig gegevens van gebruikers te bewaren hebben we je account gemarkeerd voor verwijderen. En zal verwijderd worden op ' . now()->addMonths(6)->format('d-m-Y') . '.')
+            ->line('Om de toegang tot je account te behouden vragen we je om aan te melden op het Vlaams Woordenboek om de automatische verwijdering te stoppen.');
     }
 }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\User;
+
+final readonly class UserObserver
+{
+    public function deleting(User $user): void
+    {
+        $user->suggestions()->update(['contributor_name' => $user->name]);
+    }
+}

--- a/database/factories/ArticleFactory.php
+++ b/database/factories/ArticleFactory.php
@@ -54,8 +54,8 @@ final class ArticleFactory extends Factory
         return [
             'state' => $this->faker->randomElement(ArticleStates::cases())->value,
             'part_of_speech_id' => null,
-            'author_id' => null,
-            'editor_id' => null,
+            'author_id' => User::factory()->create()->id,
+            'editor_id' => User::factory()->create()->id,
             'word' => fake()->word(),
             'views' => fake()->numberBetween(0, 1000),
             'status' => LanguageStatus::Onbekend,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -53,6 +53,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'inactivity_warning_sent_at' => null,
         ];
     }
 

--- a/database/migrations/2025_10_09_104600_add_support_for_inactive_account_deletion.php
+++ b/database/migrations/2025_10_09_104600_add_support_for_inactive_account_deletion.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('inactivity_warning_sent_at')->nullable();
+        });
+
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('contributor_name')->nullable();
+        });
+    }
+};

--- a/resources/views/emails/account-deleted.blade.php
+++ b/resources/views/emails/account-deleted.blade.php
@@ -1,0 +1,9 @@
+Hallo,
+
+Wij willen u laten weten dat uw account succesvol is verwijderd uit ons systeem.
+Dit is gebeurd omdat uw account voor een lange periode inactief was (meer dan 6 maanden).
+
+Als u vragen heeft over dit proces, neem dan gerust contact met ons op.
+
+Met vriendelijke groet,
+Het {{ config('app.name') }} Team

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\Reminders\InactivityWarningCommand;
 use App\Console\Commands\WordOfTheDayCommand;
 use Illuminate\Support\Facades\Schedule;
 
@@ -8,6 +9,8 @@ Schedule::command(WordOfTheDayCommand::class)->daily()->at('03:10');
 
 // 3th party cron commands
 Schedule::command('ban:delete-expired')->everyMinute();
+Schedule::command('notify:article-prune-reminder')->dailyAt('00:40');
+Schedule::command(InactivityWarningCommand::class)->dailyAt('00:30');
 Schedule::command('model:prune')->dailyAt('00:45');
 Schedule::command('backup:clean')->daily()->at('01:00');
 Schedule::command('backup:run')->daily()->at('01:30');


### PR DESCRIPTION
Hey @Georges-Grootjans @Taalmiet 

Deze PR staat toe dat we inactieve gebruikersaccounts automatisch gaan verwijderen. Eigenlijk werkt het vrij simpel. Gebruikers die de laatste 5 maanden zich niet hebben aangemeld krijgen een email notificatie als waarschuwing dat hun account gemarkeerd is voor verwijdering. Indien met de volgende niet meer aanmeld zal deze automatisch verwijderd worden. 

Daarnaast is aan de artikelen ook een kolom `contributor_name` toegevoegd. Voor dat de gebruiker wordt verwijderd zal hier de nickname ingeplaatst worden van de gebruiker zodat hij/zij de herkenning voor hun bijdrage niet verliest. 

De PR is momenteel nog in opbouw. Suggesties zijn welkom