### PR TITLE
V2 fix/341: Altijd tonen over welk artikel het gaat

### DIFF
--- a/app/Filament/Resources/Articles/Pages/EditWord.php
+++ b/app/Filament/Resources/Articles/Pages/EditWord.php
@@ -18,6 +18,7 @@ use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\EditRecord\Concerns\HasWizard;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\Support\Htmlable;
 use Kenepa\ResourceLock\Resources\Pages\Concerns\UsesResourceLock;
 use App\Filament\Resources\Articles\Schema\FormSchema;
 use Filament\Actions\Action;
@@ -199,5 +200,10 @@ final class EditWord extends EditRecord
         return static::getResource()::getUrl('view', [
             'record' => $this->record,
         ]);
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return ucfirst($this->record->word);
     }
 }

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -11,6 +11,7 @@ use App\Filament\Resources\Articles\Actions\States as ArticleStateActions;
 use Filament\Actions as FilamentActions;
 use Filament\Actions\ActionGroup;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Contracts\Support\Htmlable;
 
 /**
  * Represents the page for viewing a single article in the admin panel.
@@ -64,5 +65,10 @@ final class ViewWord extends ViewRecord
             FilamentActions\DeleteAction::make()->icon('heroicon-o-trash'),
             FilamentActions\RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
         ];
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return ucfirst($this->record->word);
     }
 }


### PR DESCRIPTION
Hey @Taalmiet @Georges-Grootjans 

Deze pull request stelt een fix voor omtrent ticket #341. Wat we hebben gedaan is het volgende. 
De hoofdingen van de informatie en bewerkings pagina zijn gewijzigd naar het woord in kwestie. bv: 

- Artikel bekijken => {woord in kwestie}
- Artikel bewerken => {woord in kwestie}

Is dit goed voor jullie? Of zijn er nog opmerkingen? Laat het gerust weten 
