### PR TITLE
fix(#376): Artikelen: kolommen selectie en sortering

### DIFF
--- a/app/Filament/Resources/Articles/ArticleResource.php
+++ b/app/Filament/Resources/Articles/ArticleResource.php
@@ -212,12 +212,12 @@ final class ArticleResource extends Resource
                     ->label('Toegevoegd op')
                     ->sortable()
                     ->date()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
                 TextColumn::make('updated_at')
                     ->label('Laast gewijzigd')
                     ->sortable()
                     ->date()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
             ])
             ->recordActions([
                 ViewAction::make()->hiddenLabel(),


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Group A](?expand=1&template=group_a_template.md)
* [Group B](?expand=1&template=group_b_template.md)
