### PR TITLE
Een duidelijke manier om bronnen te vermelden (implementatie nieuwe standaard)

### DIFF
--- a/app/Casts/SourceCitation.php
+++ b/app/Casts/SourceCitation.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Casts the 'source_citation' attrbiutes as the complete, enhanced source citation, including HTML tags.
+ *
+ * This class serves as a Value Object accessor, dynamically constructing the citation string by retrieving required
+ * fields from the primary Model (e.g., page reference) and its eagerly loaded or lazily loaded 'referenceWork'
+ * relationship (e.g., name, publisher). The logic is highly sensitive to the presence of data, ensuring accurate
+ * punctuation and adhering to a consistent format.
+ *
+ * @package App\Casts
+ */
+final class SourceCitation implements CastsAttributes
+{
+    /**
+     * Casts the stored model value to the desired display value (the citation string).
+     *
+     * As this is a virtual attribute, the value is fully calculated based on relationships and specific model
+     * properties, effectively providing a dynamic computed property.
+     *
+     * @param  Model  $model       The model utilizing the cast (e.g., Source).
+     * @param  string $key         The name of the attribute being cast (e.g., 'source_citation').
+     * @param  mixed  $value       The raw value from the database (ignored, but typically null).
+     * @param  array  $attributes  All model attributes.
+     * @return string              The resulting HTML formatted source citation, Returns also a fallback message.
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): string
+    {
+        return $this->buildCitationString($model);
+    }
+
+    /**
+     * Prepares the cast valie for storage.
+     *
+     * Since this is a virtual/computed read-only attribute, the incoming value is
+     * returned immediately without modification, as no storage operation is required.
+     *
+     * @param  Model  $model       The model being persisted.
+     * @param  string $key         The attribute name.
+     * @param  mixed  $value       The value to be set.
+     * @param  array  $attributes  All attributes.
+     * @return mixed
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * Core function to construct the source citation string.
+     *
+     * This method orchestrates the retrieval of components, applies styling (<em>),
+     * and enforces consistent punctuation (periods and commas) to meet the desired format.
+     *
+     * Format (example):
+     * <em>Title of the Work</em> (ABBR). Publisher, 2024. Chapter X, p. 123.
+     *
+     * @param  Model $model The primary model containing sectional data (e.g., page number).
+     * @return string       The complete and HTML-formatted source citation.
+     */
+    protected function buildCitationString(Model $model): string
+    {
+        $work = $this->getReferencedWork($model);
+
+        if (!$work) {
+            return 'Broninformatie niet beschikbaar.';
+        }
+
+        // 1. Gather and Format Components
+        $name = $work->name;
+        $abbreviation = $work->abbreviation;
+        $publisher = $work->publisher;
+
+        // Format the name in italics (<em>) as required for titles
+        $formattedName = "<em>{$name}</em>";
+
+        // Determine the year, defaulting to 'n.d.' (no date) if missing
+        $year = $work->published_at ? $work->published_at->format('Y') : 'z.j.';
+
+        // Retrieve and sanitize sectional data from the primary model
+        $section = trim((string) $model->container_section);
+        $page = trim((string) $model->page_reference);
+
+        // 2. Build the citation in sequential steps with optimized punctuation.
+        // Start with the italicized name
+        $citation = $formattedName;
+
+        if ($abbreviation) { // Add abbreviation, if present, in parentheses, appended to the name
+            $citation .= " ({$abbreviation})";
+        }
+
+        // Add the publication details block (Publisher, Year), separated by a period
+        $citation .= ". {$publisher}, {$year}";
+
+        if ($section) { // Add section, if present (separated by a period)
+            $citation .= ". {$section}";
+        }
+
+        // Add Page/Location, separated by a comma from the previous block
+        if ($page) {
+            // Use comma as separator if any publishing detail (section or publisher) precedes it.
+            if ($section || $publisher) {
+                $citation .= ", {$page}";
+            } else { // Fallback for an unlikely scenario where only the page reference exixts
+                $citation .= ". {$page}";
+            }
+        }
+
+        $citation = trim($citation);
+
+        // 3. Finalize
+        // Ensure the string ends with a single period and is properly trimmed.
+        if (!str_ends_with($citation, '.')) {
+            $citation .= '.';
+        }
+
+        return $citation;
+    }
+
+    /**
+     * Retrieves the related ReferenceWork model instance.
+     *
+     * This method implements a defensive loading strategy:
+     * 1. It checks if the 'referenceWork' relationship is already loaded (eager-loaded).
+     * 2. If not loaded, it lazily loads the first related record from the database.
+     *
+     * @param  Model $model  The model that contains the 'referenceWork' relationship.
+     * @return Model|null    The related ReferenceWork model instance or null if the relationship is empty.
+     */
+    private function getReferencedWork(Model $model): ?Model
+    {
+        return $model->relationLoaded('referenceWork')
+            ? $model->referenceWork
+            : $model->referenceWork()->first();
+    }
+}

--- a/app/Enums/Articles/ReferenceWorkType.php
+++ b/app/Enums/Articles/ReferenceWorkType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Articles;
+
+use BackedEnum;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Contracts\Support\Htmlable;
+
+enum ReferenceWorkType: int implements HasLabel, HasIcon
+{
+    case Unknown = 0;
+    case Website = 1;
+    case Journal = 2;
+    case Dictionary = 3;
+    case Newspaper = 4;
+
+    public function getLabel(): string|Htmlable|null
+    {
+        return match ($this) {
+            self::Unknown => 'Onbekend',
+            self::Website => 'Website',
+            self::Journal => 'Tijdschrift',
+            self::Dictionary => 'Woordenboek',
+            self::Newspaper => 'Krant'
+        };
+    }
+
+    public function getIcon(): string|BackedEnum|Htmlable|null
+    {
+        return null;
+    }
+}

--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/RelationManagers/ArticlesRelationManager.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/RelationManagers/ArticlesRelationManager.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Filament\Clusters\Articles\Resources\ReferenceWorks\RelationManagers;
 
 use App\Filament\Clusters\Articles\Resources\ArticleReports\ArticleReportResource;
+use App\Filament\Clusters\Articles\Resources\ReferenceWorks\Pages\ViewReferenceWork;
 use App\Filament\Resources\Articles\ArticleResource;
+use App\Models\ArticleReferenceWork;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DetachAction;
@@ -15,6 +17,7 @@ use Filament\Support\Enums\FontWeight;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Manages the articles relationship for the ReferenceWork resource.
@@ -47,6 +50,11 @@ final class ArticlesRelationManager extends RelationManager
         return false;
     }
 
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        return new $pageClass() instanceof ViewReferenceWork;
+    }
+
     /**
      * Configures the structure, columns, and behavior of the related records table.
      * This method defines how the list of associated articles is presented within the parent ReferenceWork's page.
@@ -63,27 +71,30 @@ final class ArticlesRelationManager extends RelationManager
             ->emptyStateHeading('Geen gekoppelde artikelen')
             ->emptyStateDescription('Het lijkt erop dat er momenteel geen gekoppelde artikelen zijn gevonden voor het naslagwerk')
             ->columns([
-                TextColumn::make('article.id')
-                    ->label('Artikel ID')
-                    ->weight(FontWeight::Bold)
-                    ->color('primary'),
+                TextColumn::make('article.word')
+                    ->label('Lemma')
+                    ->weight(FontWeight::ExtraBold)
+                    ->color('primary')
+                    ->url(fn (ArticleReferenceWork $articleReferenceWork): string => ArticleResource::getUrl('view', ['record' => $articleReferenceWork->article])),
 
                 TextColumn::make('article.editor.name')
                     ->label('Redacteur'),
-                TextColumn::make('article.word')
-                    ->label('Lemma'),
 
-                TextColumn::make('article.status')
+                TextColumn::make('article.state')
                     ->label('Status')
                     ->badge(),
 
-                TextColumn::make('notation')
+                TextColumn::make('container_section')
                     ->label('Referentie'),
+
+                TextColumn::make('page_reference')
+                    ->placeholder('-'),
+
                 TextColumn::make('created_at')
                     ->label('Gekoppeld sinds'),
             ])
             ->recordActions([
-                DeleteAction::make()->label('Koppeling verwijderen')
+                DeleteAction::make()->label('Ontkoppelen')
             ]);
     }
 }

--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkForm.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkForm.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\Clusters\Articles\Resources\ReferenceWorks\Schemas;
 
+use App\Enums\Articles\ReferenceWorkType;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
@@ -33,6 +36,7 @@ final readonly class ReferenceWorkForm
         return $schema
             ->components([
                 Section::make()
+                    ->icon(Heroicon::OutlinedQueueList)
                     ->heading('Naslagwerk formulier')
                     ->description('Via dit formulier kun je een nieuw naslagwerk toevoegen of een bestaan naslagwerk aanpassen.')
                     ->iconColor('primary')
@@ -54,15 +58,38 @@ final readonly class ReferenceWorkForm
         return [
             TextInput::make('abbreviation')
                 ->label('Afkorting')
-                ->columnSpan(4) // Occupies 4 out of 12 columns in the grid
+                ->columnSpan(2) // Occupies 4 out of 12 columns in the grid
+                ->unique()
                 ->required(),
+
+            Select::make('type')
+                ->columnSpan(3)
+                ->native(false)
+                ->required()
+                ->options(ReferenceWorkType::class),
 
             TextInput::make('name')
                 ->label('Naam')
                 ->required()
                 ->unique()
-                ->columnSpan(8) // Occupies 8 out of 12 columns in the grid
+                ->columnSpan(7) // Occupies 8 out of 12 columns in the grid
                 ->maxLength(255),
+
+            TextInput::make('publisher')
+                ->label('Uitgever')
+                ->required()
+                ->columnSpan(6),
+
+            DatePicker::make('published_at')
+                ->label('Publicatiedatum')
+                ->closeOnDateSelection()
+                ->native(false)
+                ->columnSpan(6),
+            TextInput::make('source-hyperlink')
+                ->label('Url')
+                ->columnSpanFull()
+                ->prefixIconColor('primary')
+                ->prefixIcon(Heroicon::OutlinedGlobeEuropeAfrica)
         ];
     }
 }

--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkInfolist.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkInfolist.php
@@ -63,9 +63,27 @@ final readonly class ReferenceWorkInfolist
                 ->columnSpan(3) // Occupies 3 out of 12 columns in the grid
                 ->placeholder('-'), // Displayed if the value is null,
 
+            TextEntry::make('type')
+                ->columnSpan(3)
+                ->badge(),
+
             TextEntry::make('name')
                 ->columnSpan(3)
                 ->label('Naam'),
+
+            TextEntry::make('url')
+                ->placeholder('-')
+                ->columnSpan(3),
+
+            TextEntry::make('publisher')
+                ->label('Uitgever')
+                ->columnSpan(3),
+
+            TextEntry::make('published_at')
+                ->label('Publicatiedatum')
+                ->date()
+                ->columnSpan(3)
+                ->placeholder('-'),
 
             TextEntry::make('created_at')
                 ->columnSpan(3)

--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Tables/ReferenceWorksTable.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Tables/ReferenceWorksTable.php
@@ -43,16 +43,26 @@ final readonly class ReferenceWorksTable
                     ->color('primary')
                     ->searchable(),
 
-                TextColumn::make('articles_count')->counts('articles'),
+                TextColumn::make('type')
+                    ->label('Type naslagwerk')
+                    ->badge(),
+
+                TextColumn::make('publisher')
+                    ->label('Uitgever'),
 
                 TextColumn::make('name')
                     ->label('Naam')
                     ->searchable(),
+
+                TextColumn::make('published_at')
+                    ->label('Publicatiedatum'),
+
                 TextColumn::make('created_at')
                     ->label('Aangemaakt op')
                     ->dateTime()
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->toggledHiddenByDefault(),
                 TextColumn::make('updated_at')
                     ->label('Laatst aangepast')
                     ->dateTime()

--- a/app/Filament/Resources/Articles/Schema/ArticleForm.php
+++ b/app/Filament/Resources/Articles/Schema/ArticleForm.php
@@ -180,8 +180,9 @@ final readonly class ArticleForm
                 ->relationship()
                 ->compact()
                 ->table([
-                    Repeater\TableColumn::make('bron')->width(400),
-                    Repeater\TableColumn::make('referentie')
+                    Repeater\TableColumn::make('Naslagwerk')->alignLeft()->width(275),
+                    Repeater\TableColumn::make('Notatie')->alignLeft(),
+                    Repeater\TableColumn::make('Pagina')->alignLeft()->width(175),
                 ])
                 ->schema([
                     Select::make('reference_work_id')
@@ -192,8 +193,10 @@ final readonly class ArticleForm
                         ->distinct()
                         ->searchable()
                         ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
-                    Textarea::make('notation')->rows(1)
-                        ->required()
+                    Textarea::make('container_section')->rows(1)
+                        ->required(),
+                    TextInput::make('page_reference')
+                        ->placeholder('p. 12 of pp. 20-30'),
                 ])
                 ->addActionLabel('Naslagwerk toevoegen')
                 ->defaultItems(0)

--- a/app/Filament/Resources/Articles/Schema/WordInfolist.php
+++ b/app/Filament/Resources/Articles/Schema/WordInfolist.php
@@ -120,17 +120,18 @@ final readonly class WordInfolist
                 RepeatableEntry::make('sources')
                     /** @phpstan-ignore-next-line  */
                     ->table([
-                        TableColumn::make('#')->alignStart()->width(100),
-                        TableColumn::make(__('filament/resources/articles.infolist.archive-information-tab.reason.table-columns.name'))->alignStart(),
+                        TableColumn::make('Type')->alignStart()->width(100),
+                        TableColumn::make(__('filament/resources/articles.infolist.archive-information-tab.reason.table-columns.name'))->width(250)->alignStart(),
                         TableColumn::make(__('filament/resources/articles.infolist.archive-information-tab.reason.table-columns.reference'))->alignStart(),
-                        TableColumn::make(__('filament/resources/articles.infolist.archive-information-tab.reason.table-columns.added-at'))->alignStart(),
+                        TableColumn::make('Pagina')->alignLeft()->width(175),
+                        TableColumn::make(__('filament/resources/articles.infolist.archive-information-tab.reason.table-columns.added-at'))->width(200)->alignStart(),
                     ])
                 ->schema([
-                    TextEntry::make('referenceWork.abbreviation')
-                        ->badge()
-                        ->icon(Heroicon::BookOpen),
+                    TextEntry::make('referenceWork.type')
+                        ->badge(),
                     TextEntry::make('referenceWork.name'),
-                    TextEntry::make('notation'),
+                    TextEntry::make('container_section'),
+                    TextEntry::make('page_reference')->placeholder('-'),
                     TextEntry::make('created_at')
                         ->date(),
                 ])

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -27,6 +27,7 @@ use Database\Factories\ArticleFactory;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;

--- a/app/Models/ArticleReferenceWork.php
+++ b/app/Models/ArticleReferenceWork.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Casts\SourceCitation;
+use App\Enums\Articles\ReferenceWorkType;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
@@ -23,5 +26,12 @@ class ArticleReferenceWork extends Pivot
     public function referenceWork(): BelongsTo
     {
         return $this->belongsTo(ReferenceWork::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'source_citation' => SourceCitation::class,
+        ];
     }
 }

--- a/app/Models/ReferenceWork.php
+++ b/app/Models/ReferenceWork.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace App\Models;
 
+use App\Enums\Articles\ReferenceWorkType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -15,5 +16,13 @@ final class ReferenceWork extends Model
     public function articles(): HasMany
     {
         return $this->hasMany(ArticleReferenceWork::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'type' => ReferenceWorkType::class,
+            'published_at' => 'date',
+        ];
     }
 }

--- a/database/migrations/2025_11_30_133001_extend_article_sources.php
+++ b/database/migrations/2025_11_30_133001_extend_article_sources.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reference_works', static function (Blueprint $table): void {
+            $table->after('id', static function (Blueprint $table): void {
+                $table->string('type');
+                $table->string('publisher');
+            });
+
+            $table->after('name', static function (Blueprint $table): void {
+                $table->dateTime('published_at')->nullable();
+            });
+        });
+
+        Schema::table('article_sources', function (Blueprint $table) {
+            $table->renameColumn('notation', 'container_section');
+            $table->string('page_reference')->nullable();
+        });
+    }
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,6 @@ parameters:
 
     excludePaths:
         - database/seeders/ShieldSeeder.php
-        - database\migrations\2025_09_02_233112_create_pulse_tables.php
 
     paths:
         - app

--- a/resources/views/definitions/show.blade.php
+++ b/resources/views/definitions/show.blade.php
@@ -238,30 +238,14 @@
 
                        @if ($word->sources()->exists())
                            <div class="tab-pane fade" id="sources-tab-pane" role="tabpanel" aria-labelledby="sources-tab" tabindex="0">
-                               <div class="table-responsive">
-                                   <table class="table table-hover table-sm mb-0">
-                                       <thead>
-                                       <tr>
-                                           <th scope="col">#</th>
-                                           <th scope="col">Naslagwerk</th>
-                                           <th scope="col">Referentie</th>
-                                       </tr>
-                                       </thead>
-                                       <tbody>
-                                       @foreach ($word->sources as $source)
-                                           <tr>
-                                               <td>
-                                                    <span class="badge badge-primary">
-                                                        <x:heroicon-s-book-open class="icon icon-sm me-1"/> {{ $source->referenceWork->abbreviation }}
-                                                    </span>
-                                               </td>
-                                               <td>{{ $source->referenceWork->name }}</td>
-                                               <td>{{ $source->notation }}</td>
-                                           </tr>
-                                       @endforeach
-                                       </tbody>
-                                   </table>
-                               </div>
+                               <ul class="list-unstyled mb-0">
+                                   @foreach($word->sources as $source)
+                                       <li>
+                                           <span class="fw-bolder me-1">{{ $loop->iteration }}.</span>
+                                           <span class="text-muted fst-italic">{!! str($source->source_citation)->sanitizeHtml() !!}</span>
+                                       </li>
+                                   @endforeach
+                               </ul>
                            </div>
                        @endif
 


### PR DESCRIPTION
## Samenvatting voor iedereen (Het 'waarom')

Dit is een belangrijke update. Hiermee zorgen we ervoor dat **alle bronvermeldingen** in ons systeem er precies hetzelfde uitzien, volgens de nieuwe, uitgewerkte organisatorische standaard. 

Het doel is om verwarring over punten, komma's, cursivering en volgorde en beeindigen. Vanaf nu bouwt het Vlaams Woordenboek de bronvermelding automatisch op, zodat deze altijd correct is en de huisstijl volgt. 

### Belangrijke impact: 

- **Geen handmatige fouten meer:** De opmaak is gegarandeerd correct. 
- **Betere leesbaarheid:** Alle artikelen gebruiken dezelfde, voorspelbare stijl. 

---

## Wat is er Technisch veranderd? *(voor het kernteam)*

De complexe logica die bepaalt hoe een bron eruitziet (de titel cursief, waar de komma's en punten staan, en hoe we omgaan met het jaar of de uitgever), is verplaatst naar één centrale plek: de `SourceCitation` **Class**.

Voordat deze wijziging er was, moesten we die opmaakregels telkens herhalen of oproepen in de code. Nu zijn de regels vastgelegd in één document en overal herbruikbaar.

## Wat gebeurd er achter de schermen?

1. Het systeem vraagt de broninformatie op uit de database (titel, uitgever, sectie, paginanummer, ...). 
2. De nieuwe `SourceCitation` class neemt deze gegevens over en past de strikte regels voor de standaard notering toe. 
3. Het resultaat is één perfect opgemaakte tekststring, klaar om weergegeven te worden. 

### De nieuwe standaard notering (zo ziet het resultaat eruit)

Dit is het exacte formaat dat deze update garandeert: 

***[Titel van het Werk]*** **([Afkorting]). [Uitgever], [Jaartal]. [Sectie/Hoofdstuk], [Paginanummer(s)].**

| Onderdeel | Opmaak | Scheiding |
| :--- | :--- | :--- |
| **Titel** | *Cursief* (`<em>`) | Wordt afgesloten met een punt (`.`) |
| **Publicatie Info** | Uitgever en Jaartal | Gescheiden door een komma (`,`) |
| **Sectie** | Normale tekst | Gescheiden door een punt (`.`) |
| **Pagina** | Normale tekst (indien aanwezig) | Gescheiden door een komma (`,`) |

**Praktijkvoorbeeld:**
```html
// Dit is wat de gebruiker of lezer ziet:
<em>Organisatorische Handboek</em> (OH). Bedrijfsbeleid B.V., 2024. Sectie A, p. 12-15.
```


