### PR TITLE
Nieuwe methode om artikelen te schrappen.

### DIFF
--- a/app/Enums/Articles/ArticleDeletionReasons.php
+++ b/app/Enums/Articles/ArticleDeletionReasons.php
@@ -1,0 +1,20 @@
+<?php 
+
+declare(strict_types=1); 
+
+namespace App\Enums\Articles;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum ArticleDeletionReasons: string implements HasLabel
+{
+    case SpeechVariation = 'Uitspraakvariant';
+    case TooRegional = 'Te regionaal';
+    case WritingVariant = 'Schrijfvariant'; 
+    case Junk = 'Rommel';
+
+    public function getLabel(): string 
+    {
+        return $this->value;
+    }
+}

--- a/app/Enums/Articles/ArticleDeletionReasons.php
+++ b/app/Enums/Articles/ArticleDeletionReasons.php
@@ -9,9 +9,13 @@ use Filament\Support\Contracts\HasLabel;
 enum ArticleDeletionReasons: string implements HasLabel
 {
     case SpeechVariation = 'Uitspraakvariant';
+    case Double = 'Dubbel';
+    case ReferenceArticle = 'Verwijsartikel'; 
+    case ImproperArticle = 'Oneigenlijk artikel';
     case TooRegional = 'Te regionaal';
     case WritingVariant = 'Schrijfvariant'; 
     case Junk = 'Rommel';
+    case Other = 'Andere';
 
     public function getLabel(): string 
     {

--- a/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
@@ -8,6 +8,7 @@ use App\Enums\ArticleStates;
 use App\Filament\Clusters\Articles\Resources\ArticleResource\Actions\BulkArchiveAction;
 use App\Filament\Exports\ArticleExporter;
 use App\Filament\Resources\Articles\Actions\SoftDeleteArticleAction;
+use App\Filament\Resources\Articles\Actions\RestoreArticleAction;
 use App\Models\Article;
 use Filament\Actions\{ActionGroup,
     BulkActionGroup,
@@ -61,7 +62,7 @@ final readonly class TableSchema
             ActionGroup::make([
                 EditAction::make()->authorizationNotification(),
                 ActionGroup::make([
-                    RestoreAction::make()->color('danger'),
+                    RestoreArticleAction::make()->color('danger'),
                     SoftDeleteArticleAction::make()->authorizationNotification(),
                     ForceDeleteAction::make()->authorizationNotification(),
                 ])->dropdown(false)

--- a/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
@@ -7,6 +7,7 @@ namespace App\Filament\Clusters\Articles\Resources\ArticleResource\Schema;
 use App\Enums\ArticleStates;
 use App\Filament\Clusters\Articles\Resources\ArticleResource\Actions\BulkArchiveAction;
 use App\Filament\Exports\ArticleExporter;
+use App\Filament\Resources\Articles\Actions\SoftDeleteArticleAction;
 use App\Models\Article;
 use Filament\Actions\{ActionGroup,
     BulkActionGroup,
@@ -61,7 +62,7 @@ final readonly class TableSchema
                 EditAction::make()->authorizationNotification(),
                 ActionGroup::make([
                     RestoreAction::make()->color('danger'),
-                    DeleteAction::make()->authorizationNotification(),
+                    SoftDeleteArticleAction::make()->authorizationNotification(),
                     ForceDeleteAction::make()->authorizationNotification(),
                 ])->dropdown(false)
             ])

--- a/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleResource/Schema/TableSchema.php
@@ -136,11 +136,11 @@ final readonly class TableSchema
 
                 BulkArchiveAction::make(),
 
-                BulkActionGroup::make([
-                    RestoreBulkAction::make(),
-                    ForceDeleteBulkAction::make(),
-                    DeleteBulkAction::make(),
-                ])->dropdown(false),
+                // BulkActionGroup::make([
+                //    RestoreBulkAction::make(),
+                //    ForceDeleteBulkAction::make(),
+                //    DeleteBulkAction::make(),
+                // ])->dropdown(false),
             ]),
         ];
     }

--- a/app/Filament/Resources/Articles/Actions/RestoreArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/RestoreArticleAction.php
@@ -1,6 +1,6 @@
 <?php 
 
-declare(striçct_types=1); 
+declare(strict_types=1); 
 
 namespace App\Filament\Resources\Articles\Actions;
 

--- a/app/Filament/Resources/Articles/Actions/RestoreArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/RestoreArticleAction.php
@@ -1,0 +1,35 @@
+<?php 
+
+declare(striçct_types=1); 
+
+namespace App\Filament\Resources\Articles\Actions;
+
+use App\Models\Article;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Actions\RestoreAction;
+
+final class RestoreArticleAction extends RestoreAction
+{
+    use CanCustomizeProcess; 
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->action(function (): void {
+            if ($this->process(fn (Article $article): bool => $this->handleArticleRestoration($article))) {
+                $this->success(); 
+                return;
+            }
+
+            $this->failure();
+        });
+    }
+
+    private function handleArticleRestoration(Article $article): bool 
+    {
+        $article->update(attributes: ['deletion_reason' => null, 'deleted_by' => null]);
+
+        return $article->restore();
+    } 
+}

--- a/app/Filament/Resources/Articles/Actions/SoftDeleteArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/SoftDeleteArticleAction.php
@@ -34,10 +34,12 @@ final class SoftDeleteArticleAction extends DeleteAction
 
     private function softDeleteArticle(Article $article, array $data): bool 
     {
-        return (bool) $article->update(attributes: [
+        $article->update(attributes: [
             'deletion_reason' => $data['deletion_reason'], 
             'deleted_by' => auth()->user()->id
         ]);
+        
+        return (bool) $article->delete();
     }
 
     private function registerCustomModalSchema(): array 

--- a/app/Filament/Resources/Articles/Actions/SoftDeleteArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/SoftDeleteArticleAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\Articles\Actions;
+
+use App\Enums\Articles\ArticleDeletionReasons;
+use App\Models\Article;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Utilities\Set;
+use Schmeits\FilamentCharacterCounter\Forms\Components\Textarea;
+
+final class SoftDeleteArticleAction extends DeleteAction 
+{
+    use CanCustomizeProcess; 
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->schema(schema: $this->registerCustomModalSchema());
+
+        $this->action(function (): void {
+            if ($this->process(fn (Article $article, array $data): bool => $this->softDeleteArticle($article, $data))) {
+                $this->success(); 
+                return;
+            }
+
+            $this->failure();
+        });
+    }
+
+    private function softDeleteArticle(Article $article, array $data): bool 
+    {
+        return (bool) $article->update(attributes: [
+            'deletion_reason' => $data['deletion_reason'], 
+            'deleted_by' => auth()->user()->id
+        ]);
+    }
+
+    private function registerCustomModalSchema(): array 
+    {
+        return [
+            Select::make('motivation')
+                ->label('Redenen')
+                ->hiddenLabel()
+                ->placeholder('selecteer een redenen')
+                ->options(ArticleDeletionReasons::class)
+                ->native(false)
+                ->afterStateUpdated(fn (Set $set, ?ArticleDeletionReasons $state): mixed => $set('deletion_reason', $state?->getLabel()))
+                ->live(),
+
+            Textarea::make('deletion_reason')
+                ->label('Reden tot verwijdering')
+                ->rows(3)
+                ->required()
+                ->placeholder('Beschrijf kort waarom het artikel verwijderd moet worden.')
+                ->characterLimit(400)
+                ->default(null)
+        ];
+    }
+}

--- a/app/Filament/Resources/Articles/Pages/EditWord.php
+++ b/app/Filament/Resources/Articles/Pages/EditWord.php
@@ -25,6 +25,7 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Kenepa\ResourceLock\Resources\Pages\Concerns\UsesResourceLock;
 use App\Filament\Resources\Articles\Schema\FormSchema;
+use App\Filament\Resources\Articles\Actions\RestoreArticleAction;
 use Filament\Actions\Action;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Notifications\Notification;
@@ -91,7 +92,7 @@ final class EditWord extends EditRecord
 
             Actions\ActionGroup::make([
                 SoftDeleteArticleAction::make()->icon('heroicon-o-trash'),
-                RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
+                RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
                 ForceDeleteAction::make()->icon('heroicon-o-trash'),
             ])->buttonGroup()
         ];

--- a/app/Filament/Resources/Articles/Pages/EditWord.php
+++ b/app/Filament/Resources/Articles/Pages/EditWord.php
@@ -15,6 +15,7 @@ use App\Models\Article;
 use App\Enums\ArticleStates;
 use App\Filament\Resources\Articles\ArticleResource;
 use App\Filament\Resources\Articles\Actions\RemoveEditorAction;
+use App\Filament\Resources\Articles\Actions\SoftDeleteArticleAction;
 use App\Filament\Resources\Articles\Actions\States\PublishArticleAction;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
@@ -89,7 +90,7 @@ final class EditWord extends EditRecord
                 ->url(route('word-information.show', $this->record), shouldOpenInNewTab: true),
 
             Actions\ActionGroup::make([
-                DeleteAction::make()->icon('heroicon-o-trash'),
+                SoftDeleteArticleAction::make()->icon('heroicon-o-trash'),
                 RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
                 ForceDeleteAction::make()->icon('heroicon-o-trash'),
             ])->buttonGroup()

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -92,8 +92,6 @@ final class ViewWord extends ViewRecord
             ->button(),
 
             SoftDeleteArticleAction::make()->icon('heroicon-o-trash'),
-            RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
-            FilamentActions\ForceDeleteAction::make()->icon('heroicon-o-trash'),
         ];
     }
 

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -10,6 +10,7 @@ use App\Filament\Resources\Articles\ArticleResource;
 use App\Filament\Resources\Articles\Actions\RevokePublication;
 use App\Filament\Resources\Articles\Actions\SoftDeleteArticleAction;
 use App\Filament\Resources\Articles\Actions\States as ArticleStateActions;
+use App\Filament\Resources\Articles\Actions\RestoreArticleAction;
 use App\Models\User;
 use Filament\Actions as FilamentActions;
 use Filament\Actions\ActionGroup;
@@ -89,7 +90,7 @@ final class ViewWord extends ViewRecord
             ->button(),
 
             SoftDeleteArticleAction::make()->icon('heroicon-o-trash'),
-            FilamentActions\RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
+            RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
             FilamentActions\ForceDeleteAction::make()->icon('heroicon-o-trash'),
         ];
     }

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\Articles\Actions\DuplicationArticleAction;
 use App\Models\Article;
 use App\Filament\Resources\Articles\ArticleResource;
 use App\Filament\Resources\Articles\Actions\RevokePublication;
+use App\Filament\Resources\Articles\Actions\SoftDeleteArticleAction;
 use App\Filament\Resources\Articles\Actions\States as ArticleStateActions;
 use App\Models\User;
 use Filament\Actions as FilamentActions;
@@ -87,7 +88,7 @@ final class ViewWord extends ViewRecord
             ->label('Publicatie')
             ->button(),
 
-            FilamentActions\DeleteAction::make()->icon('heroicon-o-trash'),
+            SoftDeleteArticleAction::make()->icon('heroicon-o-trash'),
             FilamentActions\RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
             FilamentActions\ForceDeleteAction::make()->icon('heroicon-o-trash'),
         ];

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -18,7 +18,9 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Kirschbaum\Commentions\Filament\Actions\CommentsAction;
 
 /**
@@ -95,8 +97,10 @@ final class ViewWord extends ViewRecord
         ];
     }
 
-    public function getTitle(): string
+    protected function resolveRecord(int|string $key): Model
     {
-        return ucfirst($this->record->word);
+        return static::getResource()::getModel()::query()
+            ->withTrashed()
+            ->findOrFail($key);
     }
 }

--- a/app/Filament/Resources/Articles/Schema/WordInfolist.php
+++ b/app/Filament/Resources/Articles/Schema/WordInfolist.php
@@ -13,7 +13,9 @@ use Filament\Schemas\Schema;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use App\Filament\Clusters\Articles\Resources\ArticleResource\Actions\DisclaimerToolbarActions;
+use App\Filament\Resources\Articles\Actions\RestoreArticleAction;
 use App\Models\Article;
+use Filament\Actions\ForceDeleteAction;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Collection;
@@ -66,11 +68,19 @@ final readonly class WordInfolist
                     ->columnSpanFull(),
 
                 SimpleAlert::make('delete-alert')
-                    ->description('U bekijkt momenteel een artikel dat is gemarkeerd voor verwijdering. Indien u de juiste permissies bezit kunt u via de bovenstaande knoppen het artikel permanent verwijderen of herstellen.')
+                    ->title('Verwijderd artikel')
+                    ->description(fn (Article $article): string => __('je raadpleegd momenteel een door :user verwijderd artikel. Dat gemarkeerd is wegens :reason', [
+                        'user' => $article->deletedBy->name, 
+                        'reason' => $article->deletion_reason ?? 'onbekend'
+                    ]))
                     ->columnSpanFull()
                     ->icon(Heroicon::OutlinedTrash, IconAnimation::Pulse)
                     ->visible(fn (Article $article): bool => $article->trashed())
-                    ->color('danger'),
+                    ->color('danger')
+                    ->actions([
+                        RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
+                        ForceDeleteAction::make()->icon('heroicon-o-trash'),
+                    ]),
 
                 Tabs::make('lemma-information')
                     ->columnSpan(12)

--- a/app/Filament/Resources/Articles/Schema/WordInfolist.php
+++ b/app/Filament/Resources/Articles/Schema/WordInfolist.php
@@ -70,7 +70,7 @@ final readonly class WordInfolist
                 SimpleAlert::make('delete-alert')
                     ->title('Verwijderd artikel')
                     ->description(fn (Article $article): string => __('je raadpleegd momenteel een door :user verwijderd artikel. Dat gemarkeerd is wegens :reason', [
-                        'user' => $article->deletedBy->name, 
+                        'user' => $article->deletedBy->name ?? config('app.name', 'Laravel'), 
                         'reason' => $article->deletion_reason ?? 'onbekend'
                     ]))
                     ->columnSpanFull()

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -183,6 +183,11 @@ final class Article extends Model implements AuditableContract, Commentable
             ->withTimestamps();
     }
 
+    public function deletedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'deleted_by');
+    }
+
     /**
      * Defines the relationship between an article and its disclaimer.
      *

--- a/app/Models/VolunteerApplications.php
+++ b/app/Models/VolunteerApplications.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\Volunteers\ApplicationState;
-use App\Models\Relations\BelongsToManyRegions;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Undocumented class
+ */
 final class VolunteerApplications extends Model
 {
     protected $guarded = ['id', 'user_id'];

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -287,6 +287,7 @@ final class ArticlePolicy
      */
     public function delete(User $user, Article $article): Response
     {
+        return Response::allow();
         // 1. Specific override for removing already published content
         if ($article->state->is(ArticleStates::Published) && $user->can('verwijder-vanuit-publicatie:article')) {
             return Response::allow();

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -287,7 +287,6 @@ final class ArticlePolicy
      */
     public function delete(User $user, Article $article): Response
     {
-        return Response::allow();
         // 1. Specific override for removing already published content
         if ($article->state->is(ArticleStates::Published) && $user->can('verwijder-vanuit-publicatie:article')) {
             return Response::allow();

--- a/database/migrations/2026_01_21_052908_add_deletion_reason_to_the_articles.php
+++ b/database/migrations/2026_01_21_052908_add_deletion_reason_to_the_articles.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->after('disclaimer_id', function (Blueprint $table): void {
+                $table->foreignIdFor(User::class, 'deleted_by')->nullable()->constrained()->nullOnDelete();
+                $table->text('deletion_reason')->nullable();
+            });
+        });
+    }
+};


### PR DESCRIPTION
In deze PR implemênteren we een nieuwe methode om artikelen te schrappen uit het woordenboek. 
Via deze methode kan een gebruiker met de juiste permissies een artikel zachtaardig verwijderen, mits dat hij een redenen opgeeft.

Vervolgens kan een eindredacteur of admînistrator het artikelen indien nodig bekijken en geforceerd verwijderen. Hierdoor nemen we dus de nood van een opmerking weg. Aangezien deze tot een berg notificaties leid bij de bevoegde personen. En het hun ook rechtstreeks weghoud van de essentiele taken in het Woordenboek
