### PR TITLE
  Fix #461 - Verbeterde zoekfunctie voor het woordenboek

### DIFF
--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -14,36 +14,17 @@ use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Stringable;
 
 /**
- * The SearchWordQuery provides a focused way to search through dictionary articles.
- *
- * This Query is designed to help users find articles by matching their search terms against multiple fields in the article database.
- * It specifically looks through the word itself, its description, and any associated keywords.
- * To Ensure quality results, the search only includes articles that have been published.
- *
- * The results are paginated to prevent overwhelming the user or the systeem, with six articles shown per page.
- * Users can sort these results i)àn different ways, such as alphabetically by word, by publication date, or by view count.
- *
  * @package App\Queries
  */
 final readonly class SearchWordQuery
 {
-    /**
-     * Performs the search operation using the provided search term.
-     *
-     * This method builds a query that searches though published articles, looking for matches in the word, description, and keywords fields.
-     * The search is case-insensitive and matches partial words.
-     * Results are sorted alphabetically by default and paginated for better performance and user experience
-     *
-     * @param  Request $request                  The instance that holds all the request information
-     * @return LengthAwarePaginator<int, Model>  Paginated collection of matching articles with query parameters preserved
-     */
     public function execute(Request $request): LengthAwarePaginator
     {
         $includeDescription = $request->boolean('uitgebreid');
         $includeArchive = $request->boolean('archief');
+        $isExact = $request->get('zoekpatroon') === SearchPatterns::Exact->value;
 
         return QueryBuilder::for(Article::class)
             ->allowedSorts($this->getAllowedSorts())
@@ -51,15 +32,40 @@ final readonly class SearchWordQuery
             ->with(['author', 'regions', 'bookmarkers'])
             ->where(function ($q) use ($includeArchive) {
                 $q->whereNotNull('published_at');
+
                 if ($includeArchive) {
                     $q->orWhereNotNull('archived_at');
                 }
             })
-            ->where(function ($query) use ($request, $includeDescription): void {
-                $query->where('word', $this->getSearchPattern($request)['operator'], $this->getSearchPattern($request)['pattern'])
-                    ->orWhere('keywords', $this->getSearchPattern($request)['operator'], $this->getSearchPattern($request)['pattern'])
-                    /** @phpstan-ignore-next-line */
-                    ->when($includeDescription, fn (ArticleBuilder $builder): Builder => $builder->orWhere('description', 'like', $this->getSearchPattern($request)['pattern']));
+            ->where(function ($query) use ($request, $includeDescription, $isExact): void {
+
+                // EXACT search blijft ongewijzigd
+                if ($isExact) {
+                    $pattern = $this->getSearchPattern($request);
+
+                    $query->where('word', $pattern['operator'], $pattern['pattern'])
+                        ->orWhere('keywords', $pattern['operator'], $pattern['pattern'])
+                        ->when(
+                            $includeDescription,
+                            fn (ArticleBuilder $builder): Builder =>
+                                $builder->orWhere('description', 'LIKE', $pattern['pattern'])
+                        );
+
+                    return;
+                }
+                
+                foreach ($this->getSearchTokens($request) as $token) {
+                    $query->where(function ($q) use ($token, $includeDescription) {
+                        $pattern = "%{$token}%";
+
+                        $q->where('word', 'LIKE', $pattern)
+                          ->orWhere('keywords', 'LIKE', $pattern);
+
+                        if ($includeDescription) {
+                            $q->orWhere('description', 'LIKE', $pattern);
+                        }
+                    });
+                }
             })
             ->orderBy('word')
             ->fastPaginate(6)
@@ -67,48 +73,45 @@ final readonly class SearchWordQuery
     }
 
     /**
-     * Parses the incoming request to determine the appropriate search pattern and operator for database queries.
-     * It constructs the search string (e.g., with wildcards) and identifies whether a 'LIKE' or '=' operator is needed based on the chosen `SearchPatterns` enum value.
+     * Splitst de zoekterm in losse tokens (woorden).
      *
-     * This function expects two specific parameters from the request:
-     * - 'zoekterm': The actual text to search for.
-     * - 'zoekpatroon': The desired search pattern, corresponding to a `SearchPatterns` enum case value.
-     *
-     * @param  Request $request The incoming HTTP request instance, containing 'zoekterm' and 'zoekpatroon'.
-     * @return array{pattern: Stringable|non-falsy-string, operator: '='|'LIKE'}
+     * @return array<int, string>
+     */
+    private function getSearchTokens(Request $request): array
+    {
+        return collect(
+            preg_split('/\s+/', $request->string('zoekterm')->trim()->toString())
+        )
+            ->filter(fn (string $token) => mb_strlen($token) >= 2)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Exact / klassieke LIKE-search (blijft bestaan voor specifieke zoekpatronen).
      */
     private function getSearchPattern(Request $request): array
     {
         $searchTerm = $request->string('zoekterm')->trim();
         $isExact = $request->get('zoekpatroon') === SearchPatterns::Exact->value;
 
-        // If not an exact match, replace spaces with wildcards to handle multi-word inputs.
-        // Example: 'hond hoed' becomes 'hond%hoed'
         $formattedTerm = $isExact
             ? $searchTerm->toString()
             : $searchTerm->replace(' ', '%')->toString();
 
         $pattern = match ($request->get('zoekpatroon')) {
             SearchPatterns::StartsWith->value => "{$formattedTerm}%",
-            SearchPatterns::EndsWith->value => "%{$formattedTerm}",
-            SearchPatterns::Exact->value => $formattedTerm,
-            default => "%{$formattedTerm}%",
+            SearchPatterns::EndsWith->value   => "%{$formattedTerm}",
+            SearchPatterns::Exact->value      => $formattedTerm,
+            default                           => "%{$formattedTerm}%",
         };
 
         return [
-            'pattern' => $pattern,
+            'pattern'  => $pattern,
             'operator' => $isExact ? '=' : 'LIKE',
         ];
     }
 
-    /**
-     * Provides the available sorting options for the search results.
-     *
-     * This method defines which fields can be used for sorting and maps user-friendly names to actual database columns.
-     * The alphabetical option sorts by the word itself, publication sorts by the publication date, and the views sorts by the number of times an articles has been viewed.
-     *
-     * @return array<int, AllowedSort> Collection of permitted sorting options
-     */
     private function getAllowedSorts(): array
     {
         return [
@@ -118,9 +121,6 @@ final readonly class SearchWordQuery
         ];
     }
 
-    /**
-     * @return array<int, AllowedFilter>
-     */
     private function getAllowedFilters(): array
     {
         return [

--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -131,10 +131,10 @@ final readonly class SearchWordQuery
      */
     private function getSearchTokens(Request $request): array
     {
-        return $request->collect('zoekterm')
+        return $request->string('zoekterm')
+            ->trim()
             ->explode(' ')
-            ->map(fn (string $t) => trim($t))
-            ->filter(fn (string $t) => mb_strlen($t) >= 2)
+            ->filter(fn (string $token) => mb_strlen($token) >= 2)
             ->values()
             ->all();
     }

--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -40,37 +40,77 @@ final readonly class SearchWordQuery
             ->where(function ($query) use ($request, $includeDescription, $isExact): void {
 
                 // EXACT search blijft ongewijzigd
-                if ($isExact) {
-                    $pattern = $this->getSearchPattern($request);
+                $patternType = $request->get('zoekpatroon');
 
-                    $query->where('word', $pattern['operator'], $pattern['pattern'])
-                        ->orWhere('keywords', $pattern['operator'], $pattern['pattern'])
-                        ->when(
-                            $includeDescription,
-                            fn (ArticleBuilder $builder): Builder =>
-                                $builder->orWhere('description', 'LIKE', $pattern['pattern'])
-                        );
+// EXACT = volledige string
+if ($patternType === SearchPatterns::Exact->value) {
+    $pattern = $this->getSearchPattern($request);
 
-                    return;
-                }
-                
-                foreach ($this->getSearchTokens($request) as $token) {
-                    $query->where(function ($q) use ($token, $includeDescription) {
-                        $pattern = "%{$token}%";
+    $query->where('word', '=', $pattern['pattern'])
+        ->orWhere('keywords', '=', $pattern['pattern'])
+        ->when(
+            $includeDescription,
+            fn (ArticleBuilder $builder): Builder =>
+                $builder->orWhere('description', '=', $pattern['pattern'])
+        );
 
-                        $q->where('word', 'LIKE', $pattern)
-                          ->orWhere('keywords', 'LIKE', $pattern);
+    return;
+}
 
-                        if ($includeDescription) {
-                            $q->orWhere('description', 'LIKE', $pattern);
-                        }
-                    });
+// STARTS WITH = eerste token
+if ($patternType === SearchPatterns::StartsWith->value) {
+    if ($token = $this->getBoundaryToken($request, true)) {
+        $query->where('word', 'LIKE', "{$token}%");
+    }
+
+    return;
+}
+
+// ENDS WITH = laatste token
+if ($patternType === SearchPatterns::EndsWith->value) {
+    if ($token = $this->getBoundaryToken($request, false)) {
+        $query->where('word', 'LIKE', "%{$token}");
+    }
+
+    return;
+}
+
+// DEFAULT = token-based AND-search
+foreach ($this->getSearchTokens($request) as $token) {
+    $query->where(function ($q) use ($token, $includeDescription) {
+        $pattern = "%{$token}%";
+
+        $q->where('word', 'LIKE', $pattern)
+          ->orWhere('keywords', 'LIKE', $pattern);
+
+        if ($includeDescription) {
+            $q->orWhere('description', 'LIKE', $pattern);
+        }
+    });
+}
                 }
             })
             ->orderBy('word')
             ->fastPaginate(6)
             ->appends(request()->query());
     }
+
+    /**
+ * Geeft het eerste of laatste zoekwoord terug (voor starts/ends-with).
+ */
+private function getBoundaryToken(Request $request, bool $first = true): ?string
+{
+    $tokens = $this->getSearchTokens($request);
+
+    if ($tokens === []) {
+        return null;
+    }
+
+    return $first
+        ? $tokens[0]
+        : $tokens[array_key_last($tokens)];
+}
+
 
     /**
      * Splitst de zoekterm in losse tokens (woorden).

--- a/app/Queries/SearchWordQuery.php
+++ b/app/Queries/SearchWordQuery.php
@@ -4,154 +4,144 @@ declare(strict_types=1);
 
 namespace App\Queries;
 
-use App\Builders\ArticleBuilder;
 use App\Enums\Articles\SearchPatterns;
 use App\Models\Article;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\QueryBuilder;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * @package App\Queries
  */
 final readonly class SearchWordQuery
 {
+    /**
+     * Execute the search query based on request parameters.
+     *
+     * @param Request $request
+     * @return LengthAwarePaginator
+     */
     public function execute(Request $request): LengthAwarePaginator
     {
-        $includeDescription = $request->boolean('uitgebreid');
-        $includeArchive = $request->boolean('archief');
-        $isExact = $request->get('zoekpatroon') === SearchPatterns::Exact->value;
-
         return QueryBuilder::for(Article::class)
             ->allowedSorts($this->getAllowedSorts())
             ->allowedFilters($this->getAllowedFilters())
             ->with(['author', 'regions', 'bookmarkers'])
-            ->where(function ($q) use ($includeArchive) {
-                $q->whereNotNull('published_at');
-
-                if ($includeArchive) {
-                    $q->orWhereNotNull('archived_at');
-                }
-            })
-            ->where(function ($query) use ($request, $includeDescription, $isExact): void {
-
-                // EXACT search blijft ongewijzigd
-                $patternType = $request->get('zoekpatroon');
-
-// EXACT = volledige string
-if ($patternType === SearchPatterns::Exact->value) {
-    $pattern = $this->getSearchPattern($request);
-
-    $query->where('word', '=', $pattern['pattern'])
-        ->orWhere('keywords', '=', $pattern['pattern'])
-        ->when(
-            $includeDescription,
-            fn (ArticleBuilder $builder): Builder =>
-                $builder->orWhere('description', '=', $pattern['pattern'])
-        );
-
-    return;
-}
-
-// STARTS WITH = eerste token
-if ($patternType === SearchPatterns::StartsWith->value) {
-    if ($token = $this->getBoundaryToken($request, true)) {
-        $query->where('word', 'LIKE', "{$token}%");
-    }
-
-    return;
-}
-
-// ENDS WITH = laatste token
-if ($patternType === SearchPatterns::EndsWith->value) {
-    if ($token = $this->getBoundaryToken($request, false)) {
-        $query->where('word', 'LIKE', "%{$token}");
-    }
-
-    return;
-}
-
-// DEFAULT = token-based AND-search
-foreach ($this->getSearchTokens($request) as $token) {
-    $query->where(function ($q) use ($token, $includeDescription) {
-        $pattern = "%{$token}%";
-
-        $q->where('word', 'LIKE', $pattern)
-          ->orWhere('keywords', 'LIKE', $pattern);
-
-        if ($includeDescription) {
-            $q->orWhere('description', 'LIKE', $pattern);
-        }
-    });
-}
-                }
-            })
+            ->where(fn (Builder $query) => $this->applyVisibilityFilters($query, $request))
+            ->where(fn (Builder $query) => $this->applySearchStrategy($query, $request))
             ->orderBy('word')
             ->fastPaginate(6)
-            ->appends(request()->query());
+            ->appends($request->query());
     }
 
     /**
- * Geeft het eerste of laatste zoekwoord terug (voor starts/ends-with).
- */
-private function getBoundaryToken(Request $request, bool $first = true): ?string
-{
-    $tokens = $this->getSearchTokens($request);
+     * Filter by publication and archive status.
+     *
+     * @param Builder $query
+     * @param Request $request
+     * @return void
+     */
+    private function applyVisibilityFilters(Builder $query, Request $request): void
+    {
+        $query->whereNotNull('published_at');
 
-    if ($tokens === []) {
-        return null;
+        if ($request->boolean('archief')) {
+            $query->orWhereNotNull('archived_at');
+        }
     }
 
-    return $first
-        ? $tokens[0]
-        : $tokens[array_key_last($tokens)];
-}
+    /**
+     * Determine and apply the correct search strategy.
+     *
+     * @param Builder $query
+     * @param Request $request
+     * @return void
+     */
+    private function applySearchStrategy(Builder $query, Request $request): void
+    {
+        $patternType = $request->get('zoekpatroon');
+        $includeDescription = $request->boolean('uitgebreid');
 
+        match ($patternType) {
+            SearchPatterns::Exact->value      => $this->applyExactSearch($query, $request, $includeDescription),
+            SearchPatterns::StartsWith->value => $this->applyBoundarySearch($query, $request, true),
+            SearchPatterns::EndsWith->value   => $this->applyBoundarySearch($query, $request, false),
+            default                           => $this->applyTokenizedSearch($query, $request, $includeDescription),
+        };
+    }
 
     /**
-     * Splitst de zoekterm in losse tokens (woorden).
+     * Search for the exact string in word, keywords, or description.
+     */
+    private function applyExactSearch(Builder $query, Request $request, bool $includeDescription): void
+    {
+        $term = $request->string('zoekterm')->trim()->toString();
+
+        $query->where(fn (Builder $q) => $q
+            ->where('word', $term)
+            ->orWhere('keywords', $term)
+            ->when($includeDescription, fn ($q) => $q->orWhere('description', $term))
+        );
+    }
+
+    /**
+     * Search for tokens starting or ending with a specific string.
+     */
+    private function applyBoundarySearch(Builder $query, Request $request, bool $isStart): void
+    {
+        $token = $this->getBoundaryToken($request, $isStart);
+
+        if ($token) {
+            $pattern = $isStart ? "{$token}%" : "%{$token}";
+            $query->where('word', 'LIKE', $pattern);
+        }
+    }
+
+    /**
+     * Search where every token must be present in the record (AND search).
+     */
+    private function applyTokenizedSearch(Builder $query, Request $request, bool $includeDescription): void
+    {
+        foreach ($this->getSearchTokens($request) as $token) {
+            $query->where(function (Builder $q) use ($token, $includeDescription) {
+                $wildcard = "%{$token}%";
+                $q->where('word', 'LIKE', $wildcard)
+                  ->orWhere('keywords', 'LIKE', $wildcard)
+                  ->when($includeDescription, fn ($q) => $q->orWhere('description', 'LIKE', $wildcard));
+            });
+        }
+    }
+
+    /**
+     * Get the first or last valid token from the search term.
+     */
+    private function getBoundaryToken(Request $request, bool $first): ?string
+    {
+        $tokens = $this->getSearchTokens($request);
+        return $tokens[$first ? 0 : array_key_last($tokens)] ?? null;
+    }
+
+    /**
+     * Split the search term into tokens of at least 2 characters.
      *
      * @return array<int, string>
      */
     private function getSearchTokens(Request $request): array
     {
-        return collect(
-            preg_split('/\s+/', $request->string('zoekterm')->trim()->toString())
-        )
-            ->filter(fn (string $token) => mb_strlen($token) >= 2)
+        return $request->collect('zoekterm')
+            ->explode(' ')
+            ->map(fn (string $t) => trim($t))
+            ->filter(fn (string $t) => mb_strlen($t) >= 2)
             ->values()
             ->all();
     }
 
     /**
-     * Exact / klassieke LIKE-search (blijft bestaan voor specifieke zoekpatronen).
+     * @return array<int, AllowedSort>
      */
-    private function getSearchPattern(Request $request): array
-    {
-        $searchTerm = $request->string('zoekterm')->trim();
-        $isExact = $request->get('zoekpatroon') === SearchPatterns::Exact->value;
-
-        $formattedTerm = $isExact
-            ? $searchTerm->toString()
-            : $searchTerm->replace(' ', '%')->toString();
-
-        $pattern = match ($request->get('zoekpatroon')) {
-            SearchPatterns::StartsWith->value => "{$formattedTerm}%",
-            SearchPatterns::EndsWith->value   => "%{$formattedTerm}",
-            SearchPatterns::Exact->value      => $formattedTerm,
-            default                           => "%{$formattedTerm}%",
-        };
-
-        return [
-            'pattern'  => $pattern,
-            'operator' => $isExact ? '=' : 'LIKE',
-        ];
-    }
-
     private function getAllowedSorts(): array
     {
         return [
@@ -161,6 +151,9 @@ private function getBoundaryToken(Request $request, bool $first = true): ?string
         ];
     }
 
+    /**
+     * @return array<int, AllowedFilter>
+     */
     private function getAllowedFilters(): array
     {
         return [


### PR DESCRIPTION
## Verbeterde zoekfunctie voor het woordenboek

### Wat is er veranderd?
De zoekfunctie op de website is verbeterd zodat woorden en uitdrukkingen **beter en betrouwbaarder gevonden worden**, ook wanneer gebruikers de woorden in een andere volgorde invoeren.

Dit is vooral belangrijk voor **uitdrukkingen en zegswijzen**, waar de woordvolgorde in het Nederlands en het Vlaams vaak verschilt.

---

### Waarom was dit nodig?
Voorheen werkte de zoekfunctie erg letterlijk:
- ze hield rekening met de **exacte volgorde van woorden**
- daardoor werden sommige Vlaamse uitdrukkingen niet gevonden
  wanneer gezocht werd met een Nederlandse formulering

Na een eerdere verbetering werkte “begint met” en “eindigt op” niet meer zoals verwacht bij meerdere zoekwoorden.

---

### Hoe werkt het nu?
De zoekfunctie volgt nu **taalkundig logische regels**:

- **Standaard zoeken**  
  Alle ingevoerde woorden moeten voorkomen,  
  **ongeacht de volgorde**  
  → uitdrukkingen worden correct gevonden

- **Exact zoeken**  
  Alleen een volledige, exacte overeenkomst

- **Begint met**  
  Kijkt naar het **eerste woord** van de zoekopdracht

- **Eindigt op**  
  Kijkt naar het **laatste woord** van de zoekopdracht

---

### Wat levert dit op?
- Vlaamse uitdrukkingen zijn beter vindbaar
- Zoeken werkt intuïtiever voor gebruikers
- De zoekfunctie gedraagt zich consistenter en taalcorrect
- Geen impact op bestaande inhoud of publicaties

---

### Voorbeeld
Zoeken op `brood dood` vindt nu correct de uitdrukking  
**“de een zijn dood is de ander zijn brood”**

---

### Conclusie
Deze wijziging maakt de zoekfunctie **taalkundig correcter en gebruiksvriendelijker**, zonder technische complexiteit toe te voegen voor redacteurs of gebruikers.



REF: #461