### PR TITLE
Fix :hyperlinks naar bron vermeldingen

### DIFF
--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkForm.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkForm.php
@@ -63,6 +63,13 @@ final readonly class ReferenceWorkForm
                 ->unique()
                 ->columnSpan(8) // Occupies 8 out of 12 columns in the grid
                 ->maxLength(255),
+
+            TextInput::make('external_url')
+                ->label('Hyperlink')
+                ->required()
+                ->unique()
+                ->url()
+                ->columnSpanFull()
         ];
     }
 }

--- a/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkInfolist.php
+++ b/app/Filament/Clusters/Articles/Resources/ReferenceWorks/Schemas/ReferenceWorkInfolist.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Clusters\Articles\Resources\ReferenceWorks\Schemas;
 
+use App\Models\ReferenceWork;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
@@ -71,13 +72,20 @@ final readonly class ReferenceWorkInfolist
                 ->columnSpan(3)
                 ->label('Aangemaakt op')
                 ->dateTime() // Formats the output as a data and time string
-                ->placeholder('-'),
+                ->placeholder('- niet opgegeven/gevonden'),
 
             TextEntry::make('updated_at')
                 ->dateTime()
                 ->columnSpan(3)
                 ->label('Laatst aangepast')
                 ->placeholder('-'),
+
+            TextEntry::make('external_url')
+                ->label('hyperlink')
+                ->url(fn (ReferenceWork $referenceWork): ?string => $referenceWork->external_url)
+                ->placeholder('-')
+                ->color('gray')
+                ->columnSpanFull()
         ];
     }
 }

--- a/database/migrations/2026_03_31_114157_add_external_urls_to_reference_works.php
+++ b/database/migrations/2026_03_31_114157_add_external_urls_to_reference_works.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reference_works', function (Blueprint $table) {
+            $table->after('name', function () use ($table) {
+                $table->string('external_url')->nullable()->unique();
+            });
+        });
+    }
+};

--- a/resources/views/definitions/show.blade.php
+++ b/resources/views/definitions/show.blade.php
@@ -262,17 +262,19 @@
                                             <div class="d-flex flex-column gap-2" id="source-list">
                                                 @foreach($word->sources as $source)
                                                     @if ($source->referenceWork)
-                                                        <div class="border bg-light bg-light-subtle shadow-sm rounded p-3 d-flex gap-3 align-items-start">
-                                                            <x-heroicon-s-book-open class="icon color-green flex-shrink-0 mt-1"/>
+                                                        <a href="{{ $source->referencework->external_url ?? "#" }}" class="text-decoration-none text-reset">
+                                                            <div class="border bg-light bg-light-subtle shadow-sm rounded p-3 d-flex gap-3 align-items-start h-100 transition-hover">
+                                                                <x-heroicon-s-book-open class="icon color-green flex-shrink-0 mt-1"/>
 
-                                                            <div class="flex-grow-1">
-                                                                <div class="fw-medium small">{{ optional($source->referenceWork)->name }}</div>
+                                                                <div class="flex-grow-1">
+                                                                    <div class="fw-medium small text-dark">{{ optional($source->referenceWork)->name }}</div>
 
-                                                                @if($source->notation)
-                                                                    <div class="text-muted small">{{ $source->notation }}</div>
-                                                                @endif
+                                                                    @if($source->notation)
+                                                                        <div class="text-muted small">{{ $source->notation }}</div>
+                                                                    @endif
+                                                                </div>
                                                             </div>
-                                                        </div>
+                                                        </a>
                                                     @endif
                                                 @endforeach
                                             </div>


### PR DESCRIPTION
Deze pull request voegt de functionaliteit toe om hyperlinks bij de bronnen te registreren in de beheerconsole. De gebruiker kan vervolgens op het volgende kaartje klikken. 

<img width="1033" height="94" alt="Screenshot 2026-03-31 at 2 01 46 PM" src="https://github.com/user-attachments/assets/24f5b5c1-081e-4556-9dd3-af5e612e1878" />

Na het klikken komt hij uit de de geregistreerde hyperlinks achter de bron.

Ref: #508, @Taalmiet is dit ongeveer wat je in gedachten had? 
