### PR TITLE
docs: toevoegen van docblocks in de disclaimer pages

### DIFF
--- a/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/CreateDisclaimer.php
+++ b/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/CreateDisclaimer.php
@@ -7,7 +7,25 @@ namespace App\Filament\Clusters\Articles\Resources\Disclaimers\Pages;
 use App\Filament\Clusters\Articles\Resources\Disclaimers\DisclaimerResource;
 use Filament\Resources\Pages\CreateRecord;
 
+/**
+ * Represents the page for creating a new disclaimer record in the admin panel.
+ *
+ * The `CreateDisclaimer` class extends Filament's `CreateRecord` class to provide a form-based interface
+ * for record instantiation. It is an integral part of the `DisclaimerResource` within the Articles cluster.
+ *
+ * This page allows administrators to input and save new disclaimer data into the dictionary database.
+ * It leverages the resource's defined form schema to ensure data integrity and provides a standardized
+ * workflow for expanding the dictionary's legal and informational content.
+ *
+ * @package App\Filament\Clusters\Articles\Resources\Disclaimers\Pages
+ */
 final class CreateDisclaimer extends CreateRecord
 {
+    /**
+     * Specifies the resource associated with this page.
+     *
+     * This property links the `CreateDisclaimer` page to the `DisclaimerResource`, ensuring that
+     * the correct form schema, validation rules, and model are used during the creation process.
+     */
     protected static string $resource = DisclaimerResource::class;
 }

--- a/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/EditDisclaimer.php
+++ b/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/EditDisclaimer.php
@@ -8,10 +8,37 @@ use App\Filament\Clusters\Articles\Resources\Disclaimers\DisclaimerResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
+/**
+ * Represents the page for modifying an existing disclaimer record in the admin panel.
+ *
+ * The `EditDisclaimer` class extends Filament's `EditRecord` class to provide a functional form for updating
+ * disclaimer data. It is a key component of the `DisclaimerResource` workflow within the Articles cluster.
+ *
+ * This page enables administrators to refine disclaimer text and configurations. It handles the retrieval
+ * of existing data, validation of user input, and the persistence of changes back to the database.
+ * Lifecycle actions, such as record deletion, are available in the header for streamlined management.
+ *
+ * @package App\Filament\Clusters\Articles\Resources\Disclaimers\Pages
+ */
 final class EditDisclaimer extends EditRecord
 {
+    /**
+     * Specifies the resource associated with this page.
+     *
+     * This property links to the 'EditDisclaimer' page to the 'DisclaimerResource', ensuring that
+     * the correct form schema and update logic are applied to the record being modified.
+     */
     protected static string $resource = DisclaimerResource::class;
 
+    /**
+     * Defines the actions displayed in the page header.
+     *
+     * The header actions provide supplemental tools during the editing process. Currently, it
+     * includes a delete action to allow for the immediate removal of the record directly from
+     * the edit interface, maintaining a consistent user experience.
+     *
+     * @return array<DeleteAction> An array of configured header actions.
+     */
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/ListDisclaimers.php
+++ b/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/ListDisclaimers.php
@@ -14,10 +14,35 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Support\Icons\Heroicon;
 use Laravel\Pennant\Feature;
 
+/**
+ * Represents the page for listing disclaimer records in the admin panel.
+ *
+ * The 'ListDisclaimers' class Filament's 'ListRecords' class to provide a comprehensive overview of all disclaimers.
+ * It is a component of the 'DisclaimerResource' within the Articles cluster and facilitates high-level management tasks.
+ *
+ * This page allows administrators to browse existing disclaimers, access external documentation for guidance,
+ * and utilize actions for creating new records or generating test data via factories.
+ *
+ * @package App\Filament\Clusters\articles\Resources\Disclaimers\Pages
+ */
 final class ListDisclaimers extends ListRecords
 {
+    /**
+     * Specifies the resource associated with this page.
+     *
+     * This property links the 'ListDisclaimers' page to the 'DisclaimerResource', ensuring that
+     * the correct model and table configurations are utilized for the record listing.
+     */
     protected static string $resource = DisclaimerResource::class;
 
+    /**
+     * Defines the actions displayed in the header
+     *
+     * The header actions provide essential tools for the disclaimer management workflow. This includes
+     * a conditional help button for documentation and a grouped set of actions for record instantiation.
+     *
+     * @return array<Action|ActionGroup> An array of configured header actions.
+     */
     protected function getHeaderActions(): array
     {
         return [
@@ -32,6 +57,11 @@ final class ListDisclaimers extends ListRecords
                     ->label(label: __('disclaimer-resource.header-actions.create.label'))
                     ->color('gray')
                     ->icon('heroicon-o-plus-circle'),
+
+                // Factory action
+                // ---
+                // This action is specifically included to assist developers and testers in generating
+                // mock disclaimer data directly from the UI, ensuring the dictionary stay populated during testing.
                 FactoryAction::make()
                     ->color('gray')
                     ->hiddenLabel()

--- a/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/ViewDisclaimer.php
+++ b/app/Filament/Clusters/Articles/Resources/Disclaimers/Pages/ViewDisclaimer.php
@@ -9,10 +9,37 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
 
+/**
+ * Represents the page for viewing a single disclaimer record in the admin panel.
+ *
+ * The 'ViewDisclaimer' class extends Filament's 'ViewRecord' class to provide a detailed, read-only view
+ * or a specific disclaimer's data. It is part of the 'Disclaimerresource' within the Articles cluster.
+ *
+ * This page allows administrators to review the content and metadata of a disclaimer before
+ * deciding to modify or remove it. the interface is optimized for clarity and provides
+ * direct access to lifecycle management actions to the header.
+ *
+ * @package App\Filament\Clusters\Articles\Resources\Disclaimers\Pages
+ */
 final class ViewDisclaimer extends ViewRecord
 {
+    /**
+     * Specifies the resource associated with this page.
+     *
+     * This property links the `ViewDisclaimer` page to the `DisclaimerResource`, ensuring that
+     * the correct form schema and model instance are used for displaying the record.
+     */
     protected static string $resource = DisclaimerResource::class;
 
+    /**
+     * Defines the actions displayed in the page header.
+     *
+     * The header actions provide tools for managing the current disclaimer record, including
+     * editing and deletion. These actions are styled with specific icons and colors to maintain
+     * consistency with the application's administrative design language.
+     *
+     * @return array<EditAction|DeleteAction> An array of configured header actions.
+     */
     protected function getHeaderActions(): array
     {
         return [


### PR DESCRIPTION
De pagina's binnen de disclaimer-sectie zijn voorzien van standaard 
docblocks om de leesbaarheid en onderhoudbaarheid te verbeteren, 
geheel volgens de projectstandaard.